### PR TITLE
Increase default end-to-end test timeout

### DIFF
--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "npm test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha -r ts-node/register --timeout 10000 **/*.test.ts",
+    "test": "mocha -r ts-node/register --timeout 15000 **/*.test.ts",
     "test:debug": "cross-env PWDEBUG=1 mocha -r ts-node/register --timeout 99999999 **/*.test.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch"


### PR DESCRIPTION
Recently our CI started to fail randomly due to end-to-end test timeout. My guess is that was caused by the addition of ui-framework and other packages that added a bunch more overhead to the initial page load.