### PR TITLE
Update eslint configuration

### DIFF
--- a/app/backend/.eslintrc.json
+++ b/app/backend/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "plugin:@bentley/imodeljs-recommended",
+  "extends": [
+    "plugin:@bentley/imodeljs-recommended",
+    "../../eslintrc.base.json"
+  ],
   "plugins": [
     "@bentley"
   ]

--- a/app/common/.eslintrc.json
+++ b/app/common/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "plugin:@bentley/imodeljs-recommended",
+  "extends": [
+    "plugin:@bentley/imodeljs-recommended",
+    "../../eslintrc.base.json"
+  ],
   "plugins": [
     "@bentley"
   ]

--- a/app/e2e-tests/.eslintrc.json
+++ b/app/e2e-tests/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "plugin:@bentley/imodeljs-recommended",
+  "extends": [
+    "plugin:@bentley/imodeljs-recommended",
+    "../../eslintrc.base.json"
+  ],
   "plugins": [
     "@bentley"
   ]

--- a/app/frontend/.eslintrc.json
+++ b/app/frontend/.eslintrc.json
@@ -1,9 +1,9 @@
 {
-  "extends": "plugin:@bentley/ui",
+  "extends": [
+    "plugin:@bentley/ui",
+    "../../eslintrc.base.json"
+  ],
   "plugins": [
     "@bentley"
-  ],
-  "rules": {
-    "jsx-a11y/no-onchange": "off"
-  }
+  ]
 }

--- a/components/.eslintrc.json
+++ b/components/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "plugin:@bentley/ui",
+  "extends": [
+    "plugin:@bentley/ui",
+    "../eslintrc.base.json"
+  ],
   "parserOptions": {
     "project": "tsconfig.test.json"
   },

--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    "@bentley"
+  ],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "off",
+    "jsx-a11y/no-onchange": "off",
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ]
+  }
+}


### PR DESCRIPTION
Make all eslint configuration files extend a base configuration.

Add new/disable rules:
* `@typescript-eslint/no-unused-vars`: overlaps with `tsconfig.json` setting `noUnusedLocals`.
* `object-curly-spacing`: `dbaeumer.vscode-eslint` formatter does not automatically fix curly brace spacing if this rule is not enabled. Fixing curly braces in type definitions does not work because iTwin.js uses old ESLint plugin versions.