### PR TITLE
Increase server setup timeout in end-to-end tests

### DIFF
--- a/app/e2e-tests/src/setup.ts
+++ b/app/e2e-tests/src/setup.ts
@@ -12,7 +12,7 @@ export let browser: ChromiumBrowser;
 export let page: Page;
 
 before(async function () {
-  this.timeout(60000);
+  this.timeout(90000);
   const debug = !!process.env.PWDEBUG;
 
   // mocha will hang if teardownDevServers is called before dev server finishes initialising


### PR DESCRIPTION
With recent additions of monaco editor and iTwin UI, our server startup time has now increased beyond the previous limit.