### PR TITLE
Preload homepage before beginning any tests

### DIFF
--- a/app/e2e-tests/src/setup.ts
+++ b/app/e2e-tests/src/setup.ts
@@ -23,7 +23,7 @@ before(async function () {
     setupServers({ backendPort: 3001, frontendPort: 8080, debug }),
   ]);
 
-  // Make sure the bundle is built before beginning any tests
+  // Make sure the server is responding before beginning any tests
   // eslint-disable-next-line no-console
   console.log("Preloading homepage...");
   await loadHomepage(page);


### PR DESCRIPTION
Our end-to-end tests kept timing out because the first test that runs needed to wait for the dev server to start responding.

This change adds homepage preloading step to server setup, which makes sure that tests can begin running immediately.