### PR TITLE
Update template ruleset

### DIFF
--- a/app/frontend/src/app/InitializedApp.tsx
+++ b/app/frontend/src/app/InitializedApp.tsx
@@ -89,12 +89,6 @@ export function InitializedApp(props: InitializedAppProps): React.ReactElement {
 
 const defaultRuleset: Ruleset = {
   id: "Ruleset1",
-  supportedSchemas: {
-    schemaNames: [
-      "BisCore",
-      "Functional",
-    ],
-  },
   rules: [
     {
       ruleType: RuleTypes.RootNodes,


### PR DESCRIPTION
The template ruleset populated the tree component with functional elements, but some iModels may not contain any, which would result in an empty tree.

To always populate the initial tree with content, make the template ruleset operate on polymorphic Element class, which a reasonable iModel should always contain at least some of.

Also remove the unnecessary line for setting grouping by label to `false`.