### PR TITLE
Wait for application to initialize when navigating to homepage

### DIFF
--- a/app/e2e-tests/src/utils.ts
+++ b/app/e2e-tests/src/utils.ts
@@ -6,4 +6,5 @@ import { Page } from "playwright";
 
 export async function loadHomepage(page: Page): Promise<void> {
   await page.goto("http://localhost:8080");
+  await page.waitForSelector("text=Select iModel");
 }


### PR DESCRIPTION
Another attempt to fix end-to-end test timeout flakiness. This puts waiting for application initialization outside individual test execution frame, which should help tests finish before the timeout is hit.