### PR TITLE
Update webpack to ^5.44.0

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -68,7 +68,7 @@
     "timers-browserify": "^2.0.12",
     "ts-node": "^9.1.1",
     "typescript": "^4.3.5",
-    "webpack": "^5.42.0",
+    "webpack": "^5.44.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,7 @@ importers:
       timers-browserify: ^2.0.12
       ts-node: ^9.1.1
       typescript: ^4.3.5
-      webpack: ^5.42.0
+      webpack: ^5.44.0
       webpack-cli: ^4.7.2
       webpack-dev-server: ^3.11.2
     dependencies:
@@ -190,9 +190,9 @@ importers:
       '@bentley/telemetry-client': 2.19.0-dev.6_40aa9e699d8915d5484b2356653a10a2
       '@bentley/ui-abstract': 2.19.0-dev.6_c0153e96ba10d74d8c0143b487c4de90
       '@bentley/ui-components': 2.19.0-dev.6_3c40d540540240df3cbaedf5b2580017
-      '@bentley/ui-core': 2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0
-      '@bentley/ui-framework': 2.19.0-dev.6_735a45b48587b04215eabcbe03e482c1
-      '@bentley/ui-ninezone': 2.19.0-dev.6_a7f287980e86a22e354147d097604571
+      '@bentley/ui-core': 2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589
+      '@bentley/ui-framework': 2.19.0-dev.6_e6bdcaddb1bfcf7fc99da779358ad21f
+      '@bentley/ui-ninezone': 2.19.0-dev.6_02b947d1e266facc406f437f1ebdd147
       '@bentley/webgl-compatibility': 2.19.0-dev.6_344d5c66a00fb8ec3e9a40459f830e8d
       '@itwin/itwinui-icons-react': 1.2.0_react-dom@16.14.0+react@16.14.0
       '@itwin/itwinui-react': 1.8.1_react-dom@16.14.0+react@16.14.0
@@ -200,13 +200,13 @@ importers:
       '@types/react': 16.14.6
       '@types/react-dom': 16.9.12
       buffer: 6.0.3
-      css-loader: 5.2.6_webpack@5.42.0
-      esbuild-loader: 2.13.1_webpack@5.42.0
+      css-loader: 5.2.6_webpack@5.44.0
+      esbuild-loader: 2.13.1_webpack@5.44.0
       eslint: 7.30.0
-      html-webpack-plugin: 5.3.2_webpack@5.42.0
+      html-webpack-plugin: 5.3.2_webpack@5.44.0
       https-browserify: 1.0.0
       monaco-editor: 0.25.2
-      monaco-editor-webpack-plugin: 4.0.0_14827f7ecc2275cebcfa99e990244112
+      monaco-editor-webpack-plugin: 4.0.0_5184196d246965cb6138988981516363
       npm-run-all: 4.1.5
       process: 0.11.10
       react: 16.14.0
@@ -214,17 +214,17 @@ importers:
       react-redux: 7.2.4_react-dom@16.14.0+react@16.14.0
       redux: 4.1.0
       sass: 1.32.12
-      sass-loader: 11.0.1_sass@1.32.12+webpack@5.42.0
-      source-map-loader: 2.0.1_webpack@5.42.0
+      sass-loader: 11.0.1_sass@1.32.12+webpack@5.44.0
+      source-map-loader: 2.0.1_webpack@5.44.0
       stream-browserify: 3.0.0
       stream-http: 3.2.0
-      style-loader: 2.0.0_webpack@5.42.0
+      style-loader: 2.0.0_webpack@5.44.0
       timers-browserify: 2.0.12
       ts-node: 9.1.1_typescript@4.3.5
       typescript: 4.3.5
-      webpack: 5.42.0_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.42.0
+      webpack: 5.44.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.44.0
 
   components:
     specifiers:
@@ -811,7 +811,7 @@ packages:
       '@bentley/presentation-frontend': 2.19.0-dev.6_e2db1d900288b2a545efbf9aa69c0689
       '@bentley/ui-abstract': 2.19.0-dev.6_c0153e96ba10d74d8c0143b487c4de90
       '@bentley/ui-components': 2.19.0-dev.6_3c40d540540240df3cbaedf5b2580017
-      '@bentley/ui-core': 2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0
+      '@bentley/ui-core': 2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589
       fast-deep-equal: 3.1.3
       fast-sort: 3.0.2
       immer: 9.0.2
@@ -909,7 +909,7 @@ packages:
       '@bentley/imodeljs-i18n': 2.19.0-dev.6_344d5c66a00fb8ec3e9a40459f830e8d
       '@bentley/imodeljs-quantity': 2.19.0-dev.6_344d5c66a00fb8ec3e9a40459f830e8d
       '@bentley/ui-abstract': 2.19.0-dev.6_c0153e96ba10d74d8c0143b487c4de90
-      '@bentley/ui-core': 2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0
+      '@bentley/ui-core': 2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589
       '@types/shortid': 0.0.29
       callable-instance2: 1.0.0
       classnames: 2.3.1
@@ -935,7 +935,7 @@ packages:
       ts-key-enum: 2.0.7
     dev: false
 
-  /@bentley/ui-core/2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0:
+  /@bentley/ui-core/2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589:
     resolution: {integrity: sha512-cts83IzCIYs18Maio46g/NeH8ClxmcQfJDqY06aDhsnr+ZFbnT2lmzVxXpOwEUCtYJ5kPz4os3TKkZcEgv+LDA==}
     peerDependencies:
       '@bentley/bentleyjs-core': ^2.19.0-dev.6
@@ -959,12 +959,12 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       react-select: 3.1.0_react-dom@16.14.0+react@16.14.0
       resize-observer-polyfill: 1.5.1
-      svg-sprite-loader: 4.2.1_webpack@5.42.0
+      svg-sprite-loader: 4.2.1_webpack@5.44.0
     transitivePeerDependencies:
       - webpack
     dev: false
 
-  /@bentley/ui-framework/2.19.0-dev.6_735a45b48587b04215eabcbe03e482c1:
+  /@bentley/ui-framework/2.19.0-dev.6_e6bdcaddb1bfcf7fc99da779358ad21f:
     resolution: {integrity: sha512-rGmiVgDdUmOhOLea+kMM/28LXAHipusSkTj9ZV4PLb6VgBHalrw5nCsOU4imlBmr6BB8cwAvvn1g8RdqTsyPdw==}
     peerDependencies:
       '@bentley/bentleyjs-core': ^2.19.0-dev.6
@@ -1010,8 +1010,8 @@ packages:
       '@bentley/rbac-client': 2.19.0-dev.6_40aa9e699d8915d5484b2356653a10a2
       '@bentley/ui-abstract': 2.19.0-dev.6_c0153e96ba10d74d8c0143b487c4de90
       '@bentley/ui-components': 2.19.0-dev.6_3c40d540540240df3cbaedf5b2580017
-      '@bentley/ui-core': 2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0
-      '@bentley/ui-ninezone': 2.19.0-dev.6_a7f287980e86a22e354147d097604571
+      '@bentley/ui-core': 2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589
+      '@bentley/ui-ninezone': 2.19.0-dev.6_02b947d1e266facc406f437f1ebdd147
       classnames: 2.3.1
       immer: 9.0.2
       lodash: 4.17.21
@@ -1023,12 +1023,12 @@ packages:
       react-split-pane: 0.1.92_react-dom@16.14.0+react@16.14.0
       redux: 4.1.0
       rxjs: 6.6.7
-      svg-sprite-loader: 4.2.1_webpack@5.42.0
+      svg-sprite-loader: 4.2.1_webpack@5.44.0
     transitivePeerDependencies:
       - webpack
     dev: false
 
-  /@bentley/ui-ninezone/2.19.0-dev.6_a7f287980e86a22e354147d097604571:
+  /@bentley/ui-ninezone/2.19.0-dev.6_02b947d1e266facc406f437f1ebdd147:
     resolution: {integrity: sha512-ZmL9iyaO5rRrKskQNQN6HJVlLWkTuSOBzmjJxbl/L6SOpjmh3assmJwpDRU1bKU0rUVMYaVAmKkP4bWiZUDu2g==}
     peerDependencies:
       '@bentley/bentleyjs-core': ^2.19.0-dev.6
@@ -1039,12 +1039,12 @@ packages:
     dependencies:
       '@bentley/bentleyjs-core': 2.19.0-dev.6
       '@bentley/ui-abstract': 2.19.0-dev.6_c0153e96ba10d74d8c0143b487c4de90
-      '@bentley/ui-core': 2.19.0-dev.6_ac3f080af0b8804f55555a4eb25976d0
+      '@bentley/ui-core': 2.19.0-dev.6_75a0a4d84b819c202b8d5751f258e589
       classnames: 2.3.1
       immer: 9.0.2
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      svg-sprite-loader: 4.2.1_webpack@5.42.0
+      svg-sprite-loader: 4.2.1_webpack@5.44.0
       uuid: 7.0.3
     transitivePeerDependencies:
       - webpack
@@ -1419,18 +1419,18 @@ packages:
     resolution: {integrity: sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==}
     dependencies:
       '@types/eslint': 7.2.10
-      '@types/estree': 0.0.48
+      '@types/estree': 0.0.50
     dev: false
 
   /@types/eslint/7.2.10:
     resolution: {integrity: sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==}
     dependencies:
-      '@types/estree': 0.0.48
+      '@types/estree': 0.0.50
       '@types/json-schema': 7.0.7
     dev: false
 
-  /@types/estree/0.0.48:
-    resolution: {integrity: sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==}
+  /@types/estree/0.0.50:
+    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
     dev: false
 
   /@types/glob/7.1.3:
@@ -1774,120 +1774,120 @@ packages:
     resolution: {integrity: sha512-RLwrxCTDNiNev9hpr9rDq8NyeQ8Nn0X1we4Wu7Tlf368I8r+7hBj3uObhifhuLk74egaYaSX5nUsBlWz6kjj+A==}
     dev: false
 
-  /@webassemblyjs/ast/1.11.0:
-    resolution: {integrity: sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==}
+  /@webassemblyjs/ast/1.11.1:
+    resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
     dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.0
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.0
+      '@webassemblyjs/helper-numbers': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
     dev: false
 
-  /@webassemblyjs/floating-point-hex-parser/1.11.0:
-    resolution: {integrity: sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==}
+  /@webassemblyjs/floating-point-hex-parser/1.11.1:
+    resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
     dev: false
 
-  /@webassemblyjs/helper-api-error/1.11.0:
-    resolution: {integrity: sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==}
+  /@webassemblyjs/helper-api-error/1.11.1:
+    resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
     dev: false
 
-  /@webassemblyjs/helper-buffer/1.11.0:
-    resolution: {integrity: sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==}
+  /@webassemblyjs/helper-buffer/1.11.1:
+    resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
     dev: false
 
-  /@webassemblyjs/helper-numbers/1.11.0:
-    resolution: {integrity: sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==}
+  /@webassemblyjs/helper-numbers/1.11.1:
+    resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
     dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.11.0
-      '@webassemblyjs/helper-api-error': 1.11.0
+      '@webassemblyjs/floating-point-hex-parser': 1.11.1
+      '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webassemblyjs/helper-wasm-bytecode/1.11.0:
-    resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
+  /@webassemblyjs/helper-wasm-bytecode/1.11.1:
+    resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
     dev: false
 
-  /@webassemblyjs/helper-wasm-section/1.11.0:
-    resolution: {integrity: sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==}
+  /@webassemblyjs/helper-wasm-section/1.11.1:
+    resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/helper-buffer': 1.11.0
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.0
-      '@webassemblyjs/wasm-gen': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
     dev: false
 
-  /@webassemblyjs/ieee754/1.11.0:
-    resolution: {integrity: sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==}
+  /@webassemblyjs/ieee754/1.11.1:
+    resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
     dev: false
 
-  /@webassemblyjs/leb128/1.11.0:
-    resolution: {integrity: sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==}
+  /@webassemblyjs/leb128/1.11.1:
+    resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webassemblyjs/utf8/1.11.0:
-    resolution: {integrity: sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==}
+  /@webassemblyjs/utf8/1.11.1:
+    resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
     dev: false
 
-  /@webassemblyjs/wasm-edit/1.11.0:
-    resolution: {integrity: sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==}
+  /@webassemblyjs/wasm-edit/1.11.1:
+    resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/helper-buffer': 1.11.0
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.0
-      '@webassemblyjs/helper-wasm-section': 1.11.0
-      '@webassemblyjs/wasm-gen': 1.11.0
-      '@webassemblyjs/wasm-opt': 1.11.0
-      '@webassemblyjs/wasm-parser': 1.11.0
-      '@webassemblyjs/wast-printer': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/helper-wasm-section': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/wasm-opt': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      '@webassemblyjs/wast-printer': 1.11.1
     dev: false
 
-  /@webassemblyjs/wasm-gen/1.11.0:
-    resolution: {integrity: sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==}
+  /@webassemblyjs/wasm-gen/1.11.1:
+    resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.0
-      '@webassemblyjs/ieee754': 1.11.0
-      '@webassemblyjs/leb128': 1.11.0
-      '@webassemblyjs/utf8': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/ieee754': 1.11.1
+      '@webassemblyjs/leb128': 1.11.1
+      '@webassemblyjs/utf8': 1.11.1
     dev: false
 
-  /@webassemblyjs/wasm-opt/1.11.0:
-    resolution: {integrity: sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==}
+  /@webassemblyjs/wasm-opt/1.11.1:
+    resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/helper-buffer': 1.11.0
-      '@webassemblyjs/wasm-gen': 1.11.0
-      '@webassemblyjs/wasm-parser': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
     dev: false
 
-  /@webassemblyjs/wasm-parser/1.11.0:
-    resolution: {integrity: sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==}
+  /@webassemblyjs/wasm-parser/1.11.1:
+    resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/helper-api-error': 1.11.0
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.0
-      '@webassemblyjs/ieee754': 1.11.0
-      '@webassemblyjs/leb128': 1.11.0
-      '@webassemblyjs/utf8': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-api-error': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/ieee754': 1.11.1
+      '@webassemblyjs/leb128': 1.11.1
+      '@webassemblyjs/utf8': 1.11.1
     dev: false
 
-  /@webassemblyjs/wast-printer/1.11.0:
-    resolution: {integrity: sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==}
+  /@webassemblyjs/wast-printer/1.11.1:
+    resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.0
+      '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webpack-cli/configtest/1.0.4_webpack-cli@4.7.2+webpack@5.42.0:
+  /@webpack-cli/configtest/1.0.4_webpack-cli@4.7.2+webpack@5.44.0:
     resolution: {integrity: sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.42.0_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
+      webpack: 5.44.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
     dev: false
 
   /@webpack-cli/info/1.3.0_webpack-cli@4.7.2:
@@ -1896,7 +1896,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
     dev: false
 
   /@webpack-cli/serve/1.5.1_8f539f003d3f73da23f531c906cfc201:
@@ -1908,8 +1908,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.42.0
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.44.0
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -2996,7 +2996,7 @@ packages:
     resolution: {integrity: sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==}
     dev: false
 
-  /css-loader/5.2.6_webpack@5.42.0:
+  /css-loader/5.2.6_webpack@5.44.0:
     resolution: {integrity: sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -3012,7 +3012,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 3.0.0
       semver: 7.3.5
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /css-select/2.1.0:
@@ -3599,8 +3599,8 @@ packages:
       string.prototype.trimstart: 1.0.4
       unbox-primitive: 1.0.1
 
-  /es-module-lexer/0.6.0:
-    resolution: {integrity: sha512-f8kcHX1ArhllUtb/wVSyvygoKCznIjnxhLxy7TCvIiMdT7fL4ZDTIKaadMe6eLvOXg6Wk02UeoFgUoZ2EKZZUA==}
+  /es-module-lexer/0.7.1:
+    resolution: {integrity: sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==}
     dev: false
 
   /es-to-primitive/1.2.1:
@@ -3619,7 +3619,7 @@ packages:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
     dev: false
 
-  /esbuild-loader/2.13.1_webpack@5.42.0:
+  /esbuild-loader/2.13.1_webpack@5.44.0:
     resolution: {integrity: sha512-Tzc5nB5tVUmigXz6m4j1OYozJCjdix7E9vtd5RaE54fqz2Rz34Is9S8FbAf8uqR4xvQUBAXIi6Jkn1OeMxw2aQ==}
     peerDependencies:
       webpack: ^4.40.0 || ^5.0.0
@@ -3630,7 +3630,7 @@ packages:
       loader-utils: 2.0.0
       tapable: 2.2.0
       type-fest: 1.0.2
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
       webpack-sources: 2.2.0
     dev: false
 
@@ -4752,7 +4752,7 @@ packages:
       uglify-js: 3.4.10
     dev: false
 
-  /html-webpack-plugin/3.2.0_webpack@5.42.0:
+  /html-webpack-plugin/3.2.0_webpack@5.44.0:
     resolution: {integrity: sha1-sBq71yOsqqeze2r0SS69oD2d03s=}
     engines: {node: '>=6.9'}
     deprecated: 3.x is no longer supported
@@ -4766,10 +4766,10 @@ packages:
       tapable: 1.1.3
       toposort: 1.0.7
       util.promisify: 1.0.0
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
-  /html-webpack-plugin/5.3.2_webpack@5.42.0:
+  /html-webpack-plugin/5.3.2_webpack@5.44.0:
     resolution: {integrity: sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -4780,7 +4780,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.0
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /htmlparser2/3.10.1:
@@ -6160,7 +6160,7 @@ packages:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  /monaco-editor-webpack-plugin/4.0.0_14827f7ecc2275cebcfa99e990244112:
+  /monaco-editor-webpack-plugin/4.0.0_5184196d246965cb6138988981516363:
     resolution: {integrity: sha512-4BT9XDRQXraMQjxEUjR+uuubRe3RIPkvVoGw8zwWG++s7wq6TAiXaSOMdkdS9TrjCREgSnygCOlVzY6MS8RPuA==}
     peerDependencies:
       monaco-editor: 0.25.x
@@ -6168,7 +6168,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       monaco-editor: 0.25.2
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /monaco-editor/0.25.2:
@@ -7827,7 +7827,7 @@ packages:
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass-loader/11.0.1_sass@1.32.12+webpack@5.42.0:
+  /sass-loader/11.0.1_sass@1.32.12+webpack@5.44.0:
     resolution: {integrity: sha512-Vp1LcP4slTsTNLEiDkTcm8zGN/XYYrZz2BZybQbliWA8eXveqA/AxsEjllQTpJbg2MzCsx/qNO48sHdZtOaxTw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -7846,7 +7846,7 @@ packages:
       klona: 2.0.4
       neo-async: 2.6.2
       sass: 1.32.12
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /sass/1.32.12:
@@ -8161,7 +8161,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-map-loader/2.0.1_webpack@5.42.0:
+  /source-map-loader/2.0.1_webpack@5.44.0:
     resolution: {integrity: sha512-UzOTTQhoNPeTNzOxwFw220RSRzdGSyH4lpNyWjR7Qm34P4/N0W669YSUFdH07+YNeN75h765XLHmNsF/bm97RQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -8170,7 +8170,7 @@ packages:
       abab: 2.0.5
       iconv-lite: 0.6.2
       source-map-js: 0.6.2
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /source-map-resolve/0.5.3:
@@ -8465,7 +8465,7 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /style-loader/2.0.0_webpack@5.42.0:
+  /style-loader/2.0.0_webpack@5.44.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -8473,7 +8473,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /superagent/5.3.1:
@@ -8557,7 +8557,7 @@ packages:
       traverse: 0.6.6
     dev: false
 
-  /svg-sprite-loader/4.2.1_webpack@5.42.0:
+  /svg-sprite-loader/4.2.1_webpack@5.44.0:
     resolution: {integrity: sha512-IQCJEHWD+CNP8yFptR2SkscLXBgwYwY+34VMNSLBE4RQmJ0dgpAfkF6q8ktgNsXlMhlX6cAM4Zw0t7SnLyyiQA==}
     engines: {node: '>=6'}
     dependencies:
@@ -8565,7 +8565,7 @@ packages:
       deepmerge: 1.3.2
       domready: 1.0.8
       escape-string-regexp: 1.0.5
-      html-webpack-plugin: 3.2.0_webpack@5.42.0
+      html-webpack-plugin: 3.2.0_webpack@5.44.0
       loader-utils: 1.4.0
       svg-baker: 1.7.0
       svg-baker-runtime: 1.4.7
@@ -8599,7 +8599,7 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /terser-webpack-plugin/5.1.4_webpack@5.42.0:
+  /terser-webpack-plugin/5.1.4_webpack@5.44.0:
     resolution: {integrity: sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -8611,7 +8611,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.7.0
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
     dev: false
 
   /terser/4.8.0:
@@ -9120,7 +9120,7 @@ packages:
     engines: {node: '>=10.4'}
     dev: true
 
-  /webpack-cli/4.7.2_0f369d38ac934f89ca93f1392a723bf4:
+  /webpack-cli/4.7.2_29933fd53cf71864784875ae0f2aa2d3:
     resolution: {integrity: sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -9141,7 +9141,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.2
-      '@webpack-cli/configtest': 1.0.4_webpack-cli@4.7.2+webpack@5.42.0
+      '@webpack-cli/configtest': 1.0.4_webpack-cli@4.7.2+webpack@5.44.0
       '@webpack-cli/info': 1.3.0_webpack-cli@4.7.2
       '@webpack-cli/serve': 1.5.1_8f539f003d3f73da23f531c906cfc201
       colorette: 1.2.2
@@ -9152,12 +9152,12 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.0
       v8-compile-cache: 2.3.0
-      webpack: 5.42.0_webpack-cli@4.7.2
-      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.42.0
+      webpack: 5.44.0_webpack-cli@4.7.2
+      webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.44.0
       webpack-merge: 5.7.3
     dev: false
 
-  /webpack-dev-middleware/3.7.3_webpack@5.42.0:
+  /webpack-dev-middleware/3.7.3_webpack@5.44.0:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -9167,11 +9167,11 @@ packages:
       mime: 2.5.2
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 5.42.0_webpack-cli@4.7.2
+      webpack: 5.44.0_webpack-cli@4.7.2
       webpack-log: 2.0.0
     dev: false
 
-  /webpack-dev-server/3.11.2_webpack-cli@4.7.2+webpack@5.42.0:
+  /webpack-dev-server/3.11.2_webpack-cli@4.7.2+webpack@5.44.0:
     resolution: {integrity: sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==}
     engines: {node: '>= 6.11.5'}
     hasBin: true
@@ -9211,9 +9211,9 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 5.42.0_webpack-cli@4.7.2
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
-      webpack-dev-middleware: 3.7.3_webpack@5.42.0
+      webpack: 5.44.0_webpack-cli@4.7.2
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
+      webpack-dev-middleware: 3.7.3_webpack@5.44.0
       webpack-log: 2.0.0
       ws: 6.2.1
       yargs: 13.3.2
@@ -9251,8 +9251,8 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /webpack/5.42.0_webpack-cli@4.7.2:
-    resolution: {integrity: sha512-Ln8HL0F831t1x/yPB/qZEUVmZM4w9BnHZ1EQD/sAUHv8m22hthoPniWTXEzFMh/Sf84mhrahut22TX5KxWGuyQ==}
+  /webpack/5.44.0_webpack-cli@4.7.2:
+    resolution: {integrity: sha512-I1S1w4QLoKmH19pX6YhYN0NiSXaWY8Ou00oA+aMcr9IUGeF5azns+IKBkfoAAG9Bu5zOIzZt/mN35OffBya8AQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -9262,15 +9262,15 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.0
-      '@types/estree': 0.0.48
-      '@webassemblyjs/ast': 1.11.0
-      '@webassemblyjs/wasm-edit': 1.11.0
-      '@webassemblyjs/wasm-parser': 1.11.0
+      '@types/estree': 0.0.50
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
       acorn: 8.4.1
       browserslist: 4.16.6
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.8.0
-      es-module-lexer: 0.6.0
+      es-module-lexer: 0.7.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -9281,9 +9281,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.0.0
       tapable: 2.2.0
-      terser-webpack-plugin: 5.1.4_webpack@5.42.0
+      terser-webpack-plugin: 5.1.4_webpack@5.44.0
       watchpack: 2.2.0
-      webpack-cli: 4.7.2_0f369d38ac934f89ca93f1392a723bf4
+      webpack-cli: 4.7.2_29933fd53cf71864784875ae0f2aa2d3
       webpack-sources: 2.3.0
     dev: false
 


### PR DESCRIPTION
`webpack v5.42.1` fixes a crash when attempting to modify source code while the dev server is running.

This upgrade might require you to delete `app/frontend/node_modules/.cache/webpack` to make the application build again.