### PR TITLE
Remove workaround for built-in tree and property grid auto sizer

### DIFF
--- a/app/frontend/src/app/widgets/PropertyGrid.tsx
+++ b/app/frontend/src/app/widgets/PropertyGrid.tsx
@@ -12,6 +12,7 @@ import { PropertyCategory, PropertyData, VirtualizedPropertyGridWithDataProvider
 import { Orientation, useDisposable } from "@bentley/ui-core";
 import { Button } from "@itwin/itwinui-react";
 import { appLayoutContext, AppTab } from "../AppContext";
+import { AutoSizer } from "../utils/AutoSizer";
 import { VerticalStack } from "../utils/VerticalStack";
 
 export interface PropertyGridProps {
@@ -51,12 +52,18 @@ export function PropertyGrid(props: PropertyGridProps): React.ReactElement {
   }
 
   return (
-    <VirtualizedPropertyGridWithDataProvider
-      dataProvider={dataProvider}
-      orientation={Orientation.Horizontal}
-      horizontalOrientationMinWidth={400}
-      minLabelWidth={150}
-    />
+    <AutoSizer>
+      {({ width, height }) =>
+        <VirtualizedPropertyGridWithDataProvider
+          dataProvider={dataProvider}
+          width={width}
+          height={height}
+          orientation={Orientation.Horizontal}
+          horizontalOrientationMinWidth={400}
+          minLabelWidth={150}
+        />
+      }
+    </AutoSizer>
   );
 }
 

--- a/app/frontend/src/app/widgets/Tree.tsx
+++ b/app/frontend/src/app/widgets/Tree.tsx
@@ -7,6 +7,7 @@ import { IModelConnection } from "@bentley/imodeljs-frontend";
 import { RegisteredRuleset } from "@bentley/presentation-common";
 import { usePresentationTreeNodeLoader, useUnifiedSelectionTreeEventHandler } from "@bentley/presentation-components";
 import { ControlledTree, SelectionMode, useVisibleTreeNodes } from "@bentley/ui-components";
+import { AutoSizer } from "../utils/AutoSizer";
 
 export interface TreeProps {
   imodel: IModelConnection;
@@ -24,12 +25,18 @@ export const Tree: React.FC<TreeProps> = (props) => {
   const visibleNodes = useVisibleTreeNodes(nodeLoader.modelSource);
 
   return (
-    <ControlledTree
-      visibleNodes={visibleNodes}
-      treeEvents={eventHandler}
-      nodeLoader={nodeLoader}
-      selectionMode={SelectionMode.Extended}
-      onItemsRendered={onItemsRendered}
-    />
+    <AutoSizer>
+      {({ width, height }) =>
+        <ControlledTree
+          width={width}
+          height={height}
+          visibleNodes={visibleNodes}
+          treeEvents={eventHandler}
+          nodeLoader={nodeLoader}
+          selectionMode={SelectionMode.Extended}
+          onItemsRendered={onItemsRendered}
+        />
+      }
+    </AutoSizer>
   );
 };

--- a/app/frontend/src/ui-framework/Widget/Widget.scss
+++ b/app/frontend/src/ui-framework/Widget/Widget.scss
@@ -6,6 +6,8 @@
 .nz-widget-content {
   // Make widget content occupy 100% of the height by default
   display: grid;
-  // Work-around AutoSizer issue on Chrome
-  overflow: hidden;
+
+  // Make content width and height be controlled by the widget's size
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
 }


### PR DESCRIPTION
Before there was an ability to explicitly specify tree and property grid component dimensions, we had to use a workaround which resolves scrolling issues in Chrome.

Now we can use our own auto sizer implementation and have cleaner stylesheets.