### PR TITLE
Fix tile thumbnails

### DIFF
--- a/app/frontend/src/app/IModelSelector/IModelSelector.scss
+++ b/app/frontend/src/app/IModelSelector/IModelSelector.scss
@@ -34,24 +34,6 @@
   }
 }
 
-.imodel-selector-thumbnail {
-  // Signal that local imodel thumbnail is interactive
-  cursor: pointer;
-}
-
- // Style for placeholder tiles
-.iui-tile.skeleton {
-  .iui-thumbnail .iui-skeleton {
-      width: 100%;
-      height: 100%;
-  }
-
-  .iui-content .iui-skeleton {
-    width: 178px;
-    height: 22px;
-  }
-}
-
 .iac-no-results.iac-no-results {
   // Neutralize absolute centering that @itwin/imodel-browser-react uses
   position: unset;

--- a/app/frontend/src/app/IModelSelector/IModelSelector.tsx
+++ b/app/frontend/src/app/IModelSelector/IModelSelector.tsx
@@ -7,12 +7,13 @@ import * as React from "react";
 import { useHistory } from "react-router-dom";
 import { IModelGrid, ProjectFull, ProjectGrid } from "@itwin/imodel-browser-react";
 import { SvgChevronRight, SvgImodel, SvgImodelHollow } from "@itwin/itwinui-icons-react";
-import { Button, MenuItem, ProgressRadial, Text, Tile } from "@itwin/itwinui-react";
+import { Button, MenuItem, ProgressRadial, Text } from "@itwin/itwinui-react";
 import { AuthorizationState, useAuthorization } from "../Authorization";
 import { AsyncActionButton } from "../common/AsyncActionButton";
 import { HorizontalStack, VerticalStack } from "../common/CenteredStack";
 import { LoadingIndicator } from "../common/LoadingIndicator";
 import { OfflineModeExplainer } from "../common/OfflineModeExplainer";
+import { Tile, TileSkeleton } from "../common/Tile";
 import { BackendApi } from "../ITwinJsApp/api/BackendApi";
 
 export interface IModelSelectorProps {
@@ -51,7 +52,7 @@ const OfflineSelector = React.memo((props: OfflineSelectorProps) => {
           name={name}
           thumbnail={
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-            <div className="iui-thumbnail iui-picture imodel-selector-thumbnail" onClick={handleOpen}>
+            <div onClick={handleOpen}>
               <SvgImodel />
             </div>
           }
@@ -174,9 +175,9 @@ function OfflineIModelSelectorSection(props: OfflineIModelSelectorSectionProps):
     return (
       <IModelSelectorSection title={props.title}>
         <div className="iac-grid-structure">
-          <SkeletonTile />
-          <SkeletonTile />
-          <SkeletonTile />
+          <TileSkeleton />
+          <TileSkeleton />
+          <TileSkeleton />
         </div>
       </IModelSelectorSection>
     );
@@ -206,16 +207,6 @@ function OfflineIModelSelectorSection(props: OfflineIModelSelectorSectionProps):
         {props.gridItems}
       </div>
     </IModelSelectorSection>
-  );
-}
-
-function SkeletonTile(): React.ReactElement {
-  return (
-    <Tile
-      className="skeleton"
-      name={<div className="iui-skeleton" />}
-      thumbnail={<div className="iui-skeleton" />}
-    />
   );
 }
 

--- a/app/frontend/src/app/common/Tile.scss
+++ b/app/frontend/src/app/common/Tile.scss
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+.iui-tile.clickable {
+  .iui-thumbnail-icon {
+    justify-content: center;
+    padding: 22px;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+}
+
+.iui-tile.skeleton {
+  .iui-thumbnail .iui-skeleton {
+      width: 100%;
+      height: 100%;
+  }
+
+  .iui-content .iui-skeleton {
+    width: 178px;
+    height: 22px;
+  }
+}

--- a/app/frontend/src/app/common/Tile.tsx
+++ b/app/frontend/src/app/common/Tile.tsx
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import "./Tile.scss";
+import * as React from "react";
+import { Tile as ITwinUITile, TileProps as ITwinUITileProps } from "@itwin/itwinui-react";
+
+export type TileProps = Omit<ITwinUITileProps, "className"> & { thumbnail: React.ReactElement };
+
+/** Tile that is meant to be clicked on. */
+export function Tile(props: TileProps): React.ReactElement {
+  return (
+    <ITwinUITile
+      {...props}
+      className="clickable"
+      thumbnail={React.cloneElement(props.thumbnail, { className: "iui-picture" })}
+    />
+  );
+}
+
+/** Tile that appears as if not fully loaded yet. */
+export function TileSkeleton(): React.ReactElement {
+  const skeletonDiv = <div className="iui-skeleton" />;
+  return <ITwinUITile className="skeleton" name={skeletonDiv} thumbnail={skeletonDiv} />;
+}


### PR DESCRIPTION
Tile thumbnails broke after iTwinUI-react upgrade. This PR fixes the styling issue by introducing a reusable tile component that applies necessary style overrides.

## Before

![firefox_5gtu6XPzyf](https://user-images.githubusercontent.com/70327485/136344643-f383169f-d6d7-489c-96b7-30f4c5baa9c9.png)

## After

![firefox_KaElY0hs6t](https://user-images.githubusercontent.com/70327485/136344650-6cfd055e-5ac8-4069-a9c5-effc95329b93.png)

