### PR TITLE
Configure end-to-end tests for web deployments

### DIFF
--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "start": "npm test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha -r ts-node/register --timeout 15000 --exit '**/*.test.ts'",
-    "test:debug": "cross-env PWDEBUG=1 mocha -r ts-node/register --timeout 99999999 --exit '**/*.test.ts'",
+    "test": "mocha -r ts-node/register --timeout 15000 --exit --grep '#local' '**/*.test.ts'",
+    "test:web": "cross-env WEB_TEST=1 mocha -r ts-node/register --timeout 15000 --exit --grep '#web' '**/*.test.ts'",
+    "test:debug": "cross-env PWDEBUG=1 mocha -r ts-node/register --timeout 99999999 --exit --grep '#local' '**/*.test.ts'",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch"
   },

--- a/app/e2e-tests/src/homepage.test.ts
+++ b/app/e2e-tests/src/homepage.test.ts
@@ -4,15 +4,26 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { page } from "./setup";
-import { loadHomepage } from "./utils";
+import { getServiceUrl, loadHomepage } from "./utils";
 
-describe("homepage", () => {
+describe("#local homepage", () => {
   before(async () => {
     await loadHomepage(page);
   });
 
   it("allows opening local imodel snapshot", async () => {
     await page.click('.iui-tile:has-text("Baytown.bim") .iui-thumbnail');
-    expect(page.url()).to.be.equal("http://localhost:8080/open-imodel?snapshot=Baytown.bim");
+    expect(page.url()).to.be.equal(`${getServiceUrl()}/open-imodel?snapshot=Baytown.bim`);
+  });
+});
+
+describe("#web homepage", () => {
+  before(async () => {
+    await loadHomepage(page);
+  });
+
+  it("gives options to sign in or clone", async () => {
+    expect(await page.waitForSelector("text=Sign In"));
+    expect(await page.waitForSelector("text=Clone"));
   });
 });

--- a/app/e2e-tests/src/setup.ts
+++ b/app/e2e-tests/src/setup.ts
@@ -16,6 +16,11 @@ before(async function () {
   this.timeout(120000);
   const debug = !!process.env.PWDEBUG;
 
+  if (process.env.WEB_TEST) {
+    await setupBrowser({ debug });
+    return;
+  }
+
   // mocha will hang if teardownDevServers is called before dev server finishes initialising
   await settleAllPromises([
     setupIModel(),

--- a/app/e2e-tests/src/tab-content/editor.test.ts
+++ b/app/e2e-tests/src/tab-content/editor.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import { page } from "../setup";
 import { getEditor, getWidget, openTestIModel } from "../utils";
 
-describe("editor", () => {
+describe("#local editor", () => {
   before(async () => {
     await openTestIModel(page);
   });

--- a/app/e2e-tests/src/tab-content/viewport.test.ts
+++ b/app/e2e-tests/src/tab-content/viewport.test.ts
@@ -5,7 +5,7 @@
 import { page } from "../setup";
 import { openTestIModel } from "../utils";
 
-describe("viewport", () => {
+describe("#local viewport", () => {
   before(async () => {
     await openTestIModel(page);
   });

--- a/app/e2e-tests/src/utils.ts
+++ b/app/e2e-tests/src/utils.ts
@@ -4,13 +4,17 @@
 *--------------------------------------------------------------------------------------------*/
 import { ElementHandle, Page } from "playwright";
 
+export function getServiceUrl(): string {
+  return process.env.SERVICE_URL ?? "http://localhost:8080";
+}
+
 export async function loadHomepage(page: Page): Promise<void> {
-  await page.goto("http://localhost:8080");
+  await page.goto(getServiceUrl());
   await page.waitForSelector("text=Presentation Rules Editor");
 }
 
 export async function openTestIModel(page: Page): Promise<void> {
-  await page.goto("http://localhost:8080/open-imodel?snapshot=Baytown.bim");
+  await page.goto(`${getServiceUrl()}/open-imodel?snapshot=Baytown.bim`);
   await page.waitForSelector("id=app-loader", { state: "detached" });
 }
 

--- a/app/e2e-tests/src/widgets/properties.test.ts
+++ b/app/e2e-tests/src/widgets/properties.test.ts
@@ -6,7 +6,7 @@ import { Page } from "playwright";
 import { page } from "../setup";
 import { getEditor, getWidget, openTestIModel } from "../utils";
 
-describe("properties widget", () => {
+describe("#local properties widget", () => {
   before(async () => {
     await openTestIModel(page);
   });

--- a/app/e2e-tests/src/widgets/tree.test.ts
+++ b/app/e2e-tests/src/widgets/tree.test.ts
@@ -5,7 +5,7 @@
 import { page } from "../setup";
 import { getEditor, getWidget, openTestIModel } from "../utils";
 
-describe("tree widget", () => {
+describe("#local tree widget", () => {
   before(async () => {
     await openTestIModel(page);
   });


### PR DESCRIPTION
End-to-end tests are now categorized by deployment type with `#web` and `#local` tags. Tests that are supported on both deployments may have both tags at the same time. 

`npm test` runts tests for local deployment and `npm run test:web` for web deployment. You may also set `SERVICE_URL` environment variable to point to the hosted instance of Presentation Rules Editor.