### PR TITLE
Prevent undesired package publishing pipeline triggers

### DIFF
--- a/presentation-rules-editor-react/publish.yaml
+++ b/presentation-rules-editor-react/publish.yaml
@@ -1,4 +1,6 @@
 trigger:
+  branches: none
+  pr: none
   tags:
     include:
       - v*.*.*


### PR DESCRIPTION
For some reason the publishing pipeline is being triggered by updates to any branch. This change attempts to override the implicit triggers.