### PR TITLE
Add ability to configure monaco editor contributions

### DIFF
--- a/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
@@ -161,7 +161,12 @@ function useSoloRulesetEditor(initialRuleset: Ruleset): UseSoloRulesetEditorRetu
     const editableRuleset = new EditableRuleset({
       initialRuleset: editorSettings ? parseRuleset(editorSettings.ruleset) : initialRuleset,
     });
-    const rulesetEditor = new SoloRulesetEditor({ editableRuleset, monaco, initialContent: editorSettings?.ruleset });
+    const rulesetEditor = new SoloRulesetEditor({
+      editableRuleset,
+      monaco,
+      initialContent: editorSettings?.ruleset,
+      contributions: { submitButton: true },
+    });
     result.current = { editableRuleset, rulesetEditor };
   }
 

--- a/presentation-rules-editor-react/README.md
+++ b/presentation-rules-editor-react/README.md
@@ -21,7 +21,9 @@ import { EditableRuleset, PropertyGrid, SoloRulesetEditor, Tree } from "@itwin/p
 
 function MyComponent(props: { iModel: IModelConnection }): React.ReactElement {
   const [editableRuleset] = useState(() => new EditableRuleset({ initialRuleset: ruleset }));
-  const [rulesetEditor] = useState(() => new SoloRulesetEditor({ editableRuleset, monaco }));
+  const [rulesetEditor] = useState(
+    () => new SoloRulesetEditor({ editableRuleset, monaco, contributions: { submitButton: true } }),
+  );
 
   useEffect(
     () => {


### PR DESCRIPTION
Our built-in button widget that submits the ruleset has some value, but it might not fit in well with some design decisions that we or other presentation-rules-editor-react consumers might make in the future.

It makes more sense to add this feature now before shipping the initial version of our package so that the submit button is an opt-in rather than opt-out feature.