### PR TITLE
Offer users to sign in when opening a shared link

### DIFF
--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "start": "npm test",
     "lint": "eslint ./src/**/*.{ts,tsx}",
-    "test": "mocha -r ts-node/register/transpile-only --timeout 15000 --exit --grep '#local' '**/*.test.ts'",
-    "test:web": "cross-env WEB_TEST=1 mocha -r ts-node/register/transpile-only --timeout 15000 --exit --grep '#web' '**/*.test.ts'",
+    "test": "mocha -r ts-node/register/transpile-only --timeout 30000 --exit --grep '#local' '**/*.test.ts'",
+    "test:web": "cross-env WEB_TEST=1 mocha -r ts-node/register/transpile-only --timeout 30000 --exit --grep '#web' '**/*.test.ts'",
     "test:web:junit": "npm run test:web -- --reporter mocha-junit-reporter",
     "test:debug": "cross-env PWDEBUG=1 mocha -r ts-node/register/transpile-only --timeout 99999999 --exit --grep '#local' '**/*.test.ts'",
     "typecheck": "tsc --noEmit",

--- a/app/e2e-tests/src/share.test.ts
+++ b/app/e2e-tests/src/share.test.ts
@@ -9,12 +9,12 @@ import { getEditor, getServiceUrl, getWidget, openDemoIModel, openTestIModel } f
 describe("share button #local #web", () => {
   const testConfiguration = process.env.WEB_TEST
     ? {
-      openIModel: openTestIModel,
-      expectedLink: `${getServiceUrl()}/open-imodel?snapshot=Baytown.bim#editor/N4IgTgrgNgpgzjALiAXCR9EAJKwdjAD2QF8g`,
-    }
-    : {
       openIModel: openDemoIModel,
       expectedLink: `${getServiceUrl()}/open-imodel?iTwinId=b27dc251-0e53-4a36-9a38-182fc309be07&iModelId=f30566da-8fdf-4cba-b09a-fd39f5397ae6#editor/N4IgTgrgNgpgzjALiAXCR9EAJKwdjAD2QF8g`,
+    }
+    : {
+      openIModel: openTestIModel,
+      expectedLink: `${getServiceUrl()}/open-imodel?snapshot=Baytown.bim#editor/N4IgTgrgNgpgzjALiAXCR9EAJKwdjAD2QF8g`,
     };
 
   before(async () => {
@@ -75,5 +75,22 @@ describe("opening shared link #local #web", () => {
     const editorContent = await (await editor.$(".lines-content"))?.textContent();
     // A non-breaking space is separating these words
     expect(editorContent).to.be.equal("<invalid\xa0ruleset>");
+  });
+
+  it("offers user to sign in when link points to a private iModel", async () => {
+    await page.goto(`${getServiceUrl()}/open-imodel?iTwinId=test_itwin&iModelId=test_imodel`);
+
+    const appHeader = await page.waitForSelector(".iui-page-header");
+    const options = await page.waitForSelector(".landing-page-options");
+    expect(await options?.textContent()).to.contain(
+      (process.env.WEB_TEST || await appHeader.$('text="Offline mode"') === null) ? "Sign In" : "Go to homepage",
+    );
+  });
+});
+
+describe("opening snapshot link in #web", () => {
+  it("shows user 404 error", async () => {
+    await page.goto(`${getServiceUrl()}/open-imodel?snapshot=test_snapshot`);
+    await page.waitForSelector('text="Page Not Found"');
   });
 });

--- a/app/frontend/src/app/App.tsx
+++ b/app/frontend/src/app/App.tsx
@@ -11,7 +11,7 @@ import { AppHeader } from "./AppHeader";
 import { createAuthorizationProvider, SignInCallback, SignInSilent, useAuthorization } from "./Authorization";
 import { LoadingIndicator } from "./common/LoadingIndicator";
 import { PageNotFound } from "./errors/PageNotFound";
-import { Homepage } from "./Homepage/Homepage";
+import { Homepage } from "./Homepage";
 import { ITwinJsAppData, OpenITwinIModel, OpenSnapshotIModel } from "./OpenIModel";
 import { applyUrlPrefix } from "./utils/Environment";
 

--- a/app/frontend/src/app/Homepage.tsx
+++ b/app/frontend/src/app/Homepage.tsx
@@ -5,13 +5,13 @@
 import * as React from "react";
 import { SvgUser } from "@itwin/itwinui-icons-react";
 import { Text } from "@itwin/itwinui-react";
-import { AuthorizationState, useAuthorization } from "../Authorization";
-import { CheckingSignInStatusHint } from "../common/CheckingSignInStatusHint";
-import { GitHubLogoSmall } from "../common/GitHubLogo";
-import { LandingPage } from "../common/LandingPage";
-import { Tile } from "../common/Tile";
-import { IModelSelector } from "../IModelSelector/IModelSelector";
-import { BackendApi } from "../ITwinJsApp/api/BackendApi";
+import { AuthorizationState, useAuthorization } from "./Authorization";
+import { CheckingSignInStatusHint } from "./common/CheckingSignInStatusHint";
+import { GitHubLogoSmall } from "./common/GitHubLogo";
+import { LandingPage } from "./common/LandingPage";
+import { Tile } from "./common/Tile";
+import { IModelSelector } from "./IModelSelector/IModelSelector";
+import { BackendApi } from "./ITwinJsApp/api/BackendApi";
 
 interface HomepageProps {
   backendApiPromise: Promise<BackendApi> | undefined;

--- a/app/frontend/src/app/Homepage/Homepage.tsx
+++ b/app/frontend/src/app/Homepage/Homepage.tsx
@@ -2,13 +2,13 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import "./Homepage.scss";
 import * as React from "react";
 import { SvgUser } from "@itwin/itwinui-icons-react";
 import { Text } from "@itwin/itwinui-react";
 import { AuthorizationState, useAuthorization } from "../Authorization";
 import { CheckingSignInStatusHint } from "../common/CheckingSignInStatusHint";
 import { GitHubLogoSmall } from "../common/GitHubLogo";
+import { LandingPage } from "../common/LandingPage";
 import { Tile } from "../common/Tile";
 import { IModelSelector } from "../IModelSelector/IModelSelector";
 import { BackendApi } from "../ITwinJsApp/api/BackendApi";
@@ -37,21 +37,18 @@ function WebHomepage(): React.ReactElement {
   const { signIn } = useAuthorization();
 
   return (
-    <div className="landing-page">
-      <Text variant="headline">Start using Presentation Rules Editor:</Text>
-      <div className="landing-page-options">
-        <Tile
-          thumbnail={<SvgUser onClick={signIn} />}
-          name="Sign In"
-          description="Select an iModel from your Projects"
-        />
-        <Text variant="title">or</Text>
-        <Tile
-          thumbnail={<a href="https://github.com/iTwin/presentation-rules-editor"><GitHubLogoSmall /></a>}
-          name="Clone from GitHub"
-          description="Work offline with iModel Snapshots"
-        />
-      </div>
-    </div>
+    <LandingPage headline="Start using Presentation Rules Editor:">
+      <Tile
+        thumbnail={<SvgUser onClick={signIn} />}
+        name="Sign In"
+        description="Select an iModel from your Projects"
+      />
+      <Text variant="title">or</Text>
+      <Tile
+        thumbnail={<a href="https://github.com/iTwin/presentation-rules-editor"><GitHubLogoSmall /></a>}
+        name="Clone from GitHub"
+        description="Work offline with iModel Snapshots"
+      />
+    </LandingPage>
   );
 }

--- a/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
@@ -15,7 +15,6 @@ import { ITwinLocalization } from "@itwin/core-i18n";
 import { FrontendIModelsAccess } from "@itwin/imodels-access-frontend";
 import { IModelsClient } from "@itwin/imodels-client-management";
 import { Presentation } from "@itwin/presentation-frontend";
-import { AuthorizationState, useAuthorization } from "../Authorization";
 import { LoadingIndicator } from "../common/LoadingIndicator";
 import { applyUrlPrefix } from "../utils/Environment";
 import { AuthClient, BackendApi } from "./api/BackendApi";
@@ -24,12 +23,11 @@ import { InitializedApp } from "./InitializedApp";
 
 export interface ITwinJsAppProps {
   backendApiPromise: Promise<BackendApi>;
-  imodelIdentifier: IModelIdentifier;
+  iModelIdentifier: IModelIdentifier;
 }
 
 export function ITwinJsApp(props: ITwinJsAppProps): React.ReactElement {
   const [backendApi, setBackendApi] = React.useState<BackendApi>();
-  const { state } = useAuthorization();
 
   React.useEffect(
     () => {
@@ -46,11 +44,11 @@ export function ITwinJsApp(props: ITwinJsAppProps): React.ReactElement {
     [props.backendApiPromise],
   );
 
-  if (backendApi === undefined || state === AuthorizationState.Pending) {
+  if (backendApi === undefined) {
     return <LoadingIndicator>Initializing...</LoadingIndicator>;
   }
 
-  return <InitializedApp backendApi={backendApi} imodelIdentifier={props.imodelIdentifier} />;
+  return <InitializedApp backendApi={backendApi} iModelIdentifier={props.iModelIdentifier} />;
 }
 
 export async function initializeApp(userManager: UserManager): Promise<BackendApi> {

--- a/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
@@ -25,11 +25,11 @@ import { TreeWidget } from "./widgets/TreeWidget";
 
 export interface InitializedAppProps {
   backendApi: BackendApi;
-  imodelIdentifier: IModelIdentifier;
+  iModelIdentifier: IModelIdentifier;
 }
 
 export function InitializedApp(props: InitializedAppProps): React.ReactElement | null {
-  const imodel = useIModel(props.backendApi, props.imodelIdentifier);
+  const imodel = useIModel(props.backendApi, props.iModelIdentifier);
   const { editableRuleset, rulesetEditor } = useSoloRulesetEditor(defaultRuleset);
 
   return (

--- a/app/frontend/src/app/OpenIModel.tsx
+++ b/app/frontend/src/app/OpenIModel.tsx
@@ -54,10 +54,6 @@ export function OpenITwinIModel(props: OpenITwinIModelProps): React.ReactElement
   const history = useHistory();
 
   const iModelRequiresSignIn = !isDemoIModel(props.iModelIdentifier);
-  if (props.iTwinJsApp === undefined || (iModelRequiresSignIn && state === AuthorizationState.Pending)) {
-    return <LoadingIndicator id="app-loader">Loading...</LoadingIndicator>;
-  }
-
   if (iModelRequiresSignIn && state === AuthorizationState.Offline) {
     return (
       <LandingPage headline="Cannot open this iModel while in offline mode">
@@ -72,6 +68,10 @@ export function OpenITwinIModel(props: OpenITwinIModelProps): React.ReactElement
         <Tile thumbnail={<SvgUser onClick={signIn} />} name="Sign In" />
       </LandingPage>
     );
+  }
+
+  if (props.iTwinJsApp === undefined || (iModelRequiresSignIn && state === AuthorizationState.Pending)) {
+    return <LoadingIndicator id="app-loader">Loading...</LoadingIndicator>;
   }
 
   return React.createElement(

--- a/app/frontend/src/app/OpenIModel.tsx
+++ b/app/frontend/src/app/OpenIModel.tsx
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import { useHistory } from "react-router-dom";
+import { SvgHome, SvgUser } from "@itwin/itwinui-icons-react";
+import { AuthorizationState, useAuthorization } from "./Authorization";
+import { LandingPage } from "./common/LandingPage";
+import { LoadingIndicator } from "./common/LoadingIndicator";
+import { Tile } from "./common/Tile";
+import { BackendApi } from "./ITwinJsApp/api/BackendApi";
+import { isDemoIModel, ITwinIModelIdentifier, SnapshotIModelIdentifier } from "./ITwinJsApp/IModelIdentifier";
+
+import type { ITwinJsApp } from "./ITwinJsApp/ITwinJsApp";
+
+export interface ITwinJsAppData {
+  component: typeof ITwinJsApp;
+  backendApiPromise: Promise<BackendApi>;
+}
+
+export interface OpenSnapshotIModelProps {
+  iTwinJsApp: ITwinJsAppData | undefined;
+  iModelIdentifier: SnapshotIModelIdentifier;
+}
+
+export function OpenSnapshotIModel(props: OpenSnapshotIModelProps): React.ReactElement {
+  if (props.iTwinJsApp === undefined) {
+    return <LoadingIndicator id="app-loader">Loading...</LoadingIndicator>;
+  }
+
+  return React.createElement(
+    props.iTwinJsApp.component,
+    {
+      backendApiPromise: props.iTwinJsApp.backendApiPromise,
+      iModelIdentifier: props.iModelIdentifier,
+    }
+  );
+}
+export interface OpenITwinIModelProps {
+  iTwinJsApp: ITwinJsAppData | undefined;
+  iModelIdentifier: ITwinIModelIdentifier;
+}
+
+export function OpenITwinIModel(props: OpenITwinIModelProps): React.ReactElement {
+  // ITwinJsApp component expects iModelIdentifier to be immutable, thus we have to keep the same object instance while
+  // the identifier components remain the same.
+  const iModelIdentifier: ITwinIModelIdentifier = React.useMemo(
+    () => ({ iModelId: props.iModelIdentifier.iModelId, iTwinId: props.iModelIdentifier.iTwinId }),
+    [props.iModelIdentifier.iModelId, props.iModelIdentifier.iTwinId]
+  );
+
+  const { state, signIn } = useAuthorization();
+  const history = useHistory();
+
+  const iModelRequiresSignIn = !isDemoIModel(props.iModelIdentifier);
+  if (props.iTwinJsApp === undefined || (iModelRequiresSignIn && state === AuthorizationState.Pending)) {
+    return <LoadingIndicator id="app-loader">Loading...</LoadingIndicator>;
+  }
+
+  if (iModelRequiresSignIn && state === AuthorizationState.Offline) {
+    return (
+      <LandingPage headline="Cannot open this iModel while in offline mode">
+        <Tile thumbnail={<SvgHome onClick={() => history.push("/")} />} name="Go to homepage" />
+      </LandingPage>
+    );
+  }
+
+  if (iModelRequiresSignIn && state === AuthorizationState.SignedOut) {
+    return (
+      <LandingPage headline="Sign In to access this iModel:">
+        <Tile thumbnail={<SvgUser onClick={signIn} />} name="Sign In" />
+      </LandingPage>
+    );
+  }
+
+  return React.createElement(
+    props.iTwinJsApp.component,
+    {
+      backendApiPromise: props.iTwinJsApp.backendApiPromise,
+      iModelIdentifier,
+    }
+  );
+}

--- a/app/frontend/src/app/common/LandingPage.scss
+++ b/app/frontend/src/app/common/LandingPage.scss
@@ -12,8 +12,7 @@
 }
 
 .landing-page-options {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  display: flex;
   gap: 24px;
   align-items: center;
 }

--- a/app/frontend/src/app/common/LandingPage.tsx
+++ b/app/frontend/src/app/common/LandingPage.tsx
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import "./LandingPage.scss";
+import * as React from "react";
+import { Text } from "@itwin/itwinui-react";
+
+export interface LandingPageProps {
+  headline: string;
+  children: React.ReactElement | React.ReactElement[];
+}
+
+export function LandingPage(props: LandingPageProps): React.ReactElement {
+  return (
+    <div className="landing-page">
+      <Text variant="headline">{props.headline}</Text>
+      <div className="landing-page-options">
+        {props.children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
When a user is not signed in and tries to navigate to a link which opens Presentation Rules Editor with a predetermined iModel, we will now prompt the user to sign in before they can view the ruleset.

After signing in, we now always come back to the page where the sign in was initiated.