### PR TITLE
Display opened iModel information in the app header

### DIFF
--- a/app/e2e-tests/src/header.test.ts
+++ b/app/e2e-tests/src/header.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { page } from "./setup";
+import { openDemoIModel, openTestIModel } from "./utils";
+
+describe("header #local", () => {
+  before(async () => {
+    await openTestIModel(page);
+  });
+
+  it("populates header with opened snapshot information", async () => {
+    const header = await page.waitForSelector(".iui-page-header nav");
+    expect(await header.waitForSelector('text="Local snapshots"'));
+    expect(await header.waitForSelector("text=Baytown.bim"));
+  });
+
+  it("clears breadcrumbs after navigating to home", async () => {
+    await page.click('text="Presentation Rules Editor"');
+    const header = await page.waitForSelector(".iui-page-header nav", { state: "attached" });
+    expect(await header.textContent()).to.be.empty;
+  });
+});
+
+describe("header #web", () => {
+  before(async () => {
+    await openDemoIModel(page);
+  });
+
+  it("populates header with opened demo iModel information", async () => {
+    const header = await page.waitForSelector(".iui-page-header nav");
+    expect(header.$('text="Demo iModel"'));
+    expect(header.$('text="Bay Town Process Plant"'));
+  });
+
+  it("clears breadcrumbs after navigating to home", async () => {
+    await page.click('text="Presentation Rules Editor"');
+    const header = await page.waitForSelector(".iui-page-header nav", { state: "attached" });
+    expect(await header.textContent()).to.be.empty;
+  });
+});

--- a/app/frontend/src/app/ITwinApi.ts
+++ b/app/frontend/src/app/ITwinApi.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { User } from "oidc-client";
+import { applyUrlPrefix } from "./utils/Environment";
+
+export interface Project {
+  id: string;
+  displayName: string;
+  projectNumber: string;
+  registrationDateTime: string;
+  registeredBy: string;
+  geographicLocation: string;
+  latitude: string;
+  longitude: string;
+  timeZone: string;
+  dataCenterLocation: string;
+  billingCountry: string;
+  status: string;
+  allowExternalTeamMembers: boolean;
+  _links: Links<"forms" | "imodels" | "issues" | "storage">;
+}
+
+export async function getProject(projectId: string, user: User): Promise<Project> {
+  const response = await callITwinApi(`projects/${projectId}`, user);
+  return response.project;
+}
+
+export interface IModel {
+  id: string;
+  displayName: string;
+  name: string;
+  description: string | null;
+  state: string;
+  createdDateTime: string;
+  projectId: string;
+  extent: {
+    southWest: GeoCoordinates;
+    northEast: GeoCoordinates;
+  } | null;
+  _links: Links<"changesets" | "creator" | "namedVersions">;
+}
+
+interface GeoCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export async function getIModel(iModelId: string, user: User): Promise<IModel> {
+  const response = await callITwinApi(`imodels/${iModelId}`, user);
+  return response.iModel;
+}
+
+type Links<T extends string> = {
+  [K in T]: { href: string };
+};
+
+async function callITwinApi(endpoint: string, user: User): Promise<any> {
+  const response = await fetch(
+    applyUrlPrefix("https://api.bentley.com/") + endpoint,
+    {
+      headers: {
+        Authorization: `${user.token_type} ${user.access_token}`,
+        Accept: "application/vnd.bentley.itwin-platform.v1+json",
+      },
+    },
+  );
+  return response.json();
+}

--- a/app/frontend/src/app/ITwinJsApp/IModelIdentifier.tsx
+++ b/app/frontend/src/app/ITwinJsApp/IModelIdentifier.tsx
@@ -16,50 +16,48 @@ export function isSnapshotIModel(identifier: IModelIdentifier): identifier is Sn
 }
 
 export function isDemoIModel(identifier: IModelIdentifier): boolean {
-  return !isSnapshotIModel(identifier) && demoIModelsIndex.get(identifier.iModelId) === identifier.iTwinId;
+  return !isSnapshotIModel(identifier) && demoIModels.get(identifier.iModelId)?.iTwinId === identifier.iTwinId;
 }
 
 export const demoIModels = new Map([
   [
-    "CoffsHarborDemo",
-    { iTwinId: "c5d4dd3a-597a-4c88-918c-f1aa3588312f", iModelId: "11977591-6a15-4f0e-aa10-1c6afb066bc7" },
+    "11977591-6a15-4f0e-aa10-1c6afb066bc7",
+    { name: "CoffsHarborDemo", iTwinId: "c5d4dd3a-597a-4c88-918c-f1aa3588312f" },
   ],
   [
-    "Metrostation",
-    { iTwinId: "402f1a92-c7b1-4012-b787-7fa45e2e7fe4", iModelId: "b55dec38-d9b7-4029-9b9c-6b899151328f" },
+    "b55dec38-d9b7-4029-9b9c-6b899151328f",
+    { name: "Metrostation", iTwinId: "402f1a92-c7b1-4012-b787-7fa45e2e7fe4" },
   ],
   [
-    "Retail Building",
-    { iTwinId: "998b4696-a672-4f85-bea1-8e35e0852452", iModelId: "97a67f36-8efa-499c-a6ed-a8e07f38a410" },
+    "97a67f36-8efa-499c-a6ed-a8e07f38a410",
+    { name: "Retail Building", iTwinId: "998b4696-a672-4f85-bea1-8e35e0852452" },
   ],
   [
-    "Bay Town Process Plant",
-    { iTwinId: "b27dc251-0e53-4a36-9a38-182fc309be07", iModelId: "f30566da-8fdf-4cba-b09a-fd39f5397ae6" },
+    "f30566da-8fdf-4cba-b09a-fd39f5397ae6",
+    { name: "Bay Town Process Plant", iTwinId: "b27dc251-0e53-4a36-9a38-182fc309be07" },
   ],
   [
-    "House",
-    { iTwinId: "6b9d3c0b-1217-4cf8-a1c0-afcade43e66a", iModelId: "6be3a56d-b93b-4a3c-a41e-06398083905d" },
+    "6be3a56d-b93b-4a3c-a41e-06398083905d",
+    { name: "House", iTwinId: "6b9d3c0b-1217-4cf8-a1c0-afcade43e66a" },
   ],
   [
-    "Philadelphia",
-    { iTwinId: "402f1a92-c7b1-4012-b787-7fa45e2e7fe4", iModelId: "f815bddf-c448-47c6-84d1-94762d85b645" },
+    "f815bddf-c448-47c6-84d1-94762d85b645",
+    { name: "Philadelphia", iTwinId: "402f1a92-c7b1-4012-b787-7fa45e2e7fe4" },
   ],
   [
-    "Stadium",
-    { iTwinId: "656dd74d-8798-4aa4-8d13-6e6458789639", iModelId: "881c9ca0-34ff-4875-ae63-2dd8ac015c27" },
+    "881c9ca0-34ff-4875-ae63-2dd8ac015c27",
+    { name: "Stadium", iTwinId: "656dd74d-8798-4aa4-8d13-6e6458789639" },
   ],
   [
-    "Transformed Stadium",
-    { iTwinId: "58262a3d-bbc8-45d0-adbc-13a4623c180f", iModelId: "67cf8408-8f3f-4a3a-bde1-a991a422e909" },
+    "67cf8408-8f3f-4a3a-bde1-a991a422e909",
+    { name: "Transformed Stadium", iTwinId: "58262a3d-bbc8-45d0-adbc-13a4623c180f" },
   ],
   [
-    "Exton Campus",
-    { iTwinId: "5b4ebd22-d94b-456b-8bd8-d59563de9acd", iModelId: "d992e912-7f6f-4bd6-9781-4ecf2891b17a" },
+    "d992e912-7f6f-4bd6-9781-4ecf2891b17a",
+    { name: "Exton Campus", iTwinId: "5b4ebd22-d94b-456b-8bd8-d59563de9acd" },
   ],
   [
-    "Villa",
-    { iTwinId: "532629d2-d25e-4a00-9fb7-c401b6cacf84", iModelId: "62d521ca-0b45-4a65-9f48-9fc9b5e87100" },
+    "62d521ca-0b45-4a65-9f48-9fc9b5e87100",
+    { name: "Villa", iTwinId: "532629d2-d25e-4a00-9fb7-c401b6cacf84" },
   ],
 ]);
-
-const demoIModelsIndex = new Map([...demoIModels.values()].map(({ iTwinId, iModelId }) => [iModelId, iTwinId]));

--- a/app/frontend/src/app/OpenIModel.tsx
+++ b/app/frontend/src/app/OpenIModel.tsx
@@ -2,15 +2,21 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import { User } from "oidc-client";
 import * as React from "react";
 import { useHistory } from "react-router-dom";
 import { SvgHome, SvgUser } from "@itwin/itwinui-icons-react";
+import { HeaderButton } from "@itwin/itwinui-react";
+import { appLayoutContext } from "./AppContext";
 import { AuthorizationState, useAuthorization } from "./Authorization";
 import { LandingPage } from "./common/LandingPage";
 import { LoadingIndicator } from "./common/LoadingIndicator";
 import { Tile } from "./common/Tile";
+import { getIModel, getProject } from "./ITwinApi";
 import { BackendApi } from "./ITwinJsApp/api/BackendApi";
-import { isDemoIModel, ITwinIModelIdentifier, SnapshotIModelIdentifier } from "./ITwinJsApp/IModelIdentifier";
+import {
+  demoIModels, isDemoIModel, ITwinIModelIdentifier, SnapshotIModelIdentifier,
+} from "./ITwinJsApp/IModelIdentifier";
 
 import type { ITwinJsApp } from "./ITwinJsApp/ITwinJsApp";
 
@@ -25,6 +31,20 @@ export interface OpenSnapshotIModelProps {
 }
 
 export function OpenSnapshotIModel(props: OpenSnapshotIModelProps): React.ReactElement {
+  const { setBreadcrumbs } = React.useContext(appLayoutContext);
+
+  React.useEffect(
+    () => {
+      setBreadcrumbs([
+        <HeaderButton key="iTwin" name="Local snapshots" />,
+        <HeaderButton key="iModel" name={props.iModelIdentifier} />,
+      ]);
+
+      return () => setBreadcrumbs([]);
+    },
+    [props.iModelIdentifier, setBreadcrumbs],
+  );
+
   if (props.iTwinJsApp === undefined) {
     return <LoadingIndicator id="app-loader">Loading...</LoadingIndicator>;
   }
@@ -50,10 +70,11 @@ export function OpenITwinIModel(props: OpenITwinIModelProps): React.ReactElement
     [props.iModelIdentifier.iModelId, props.iModelIdentifier.iTwinId]
   );
 
-  const { state, signIn } = useAuthorization();
+  const { state, user, signIn } = useAuthorization();
+  usePopulateHeaderBreadcrumbs(iModelIdentifier, user);
   const history = useHistory();
 
-  const iModelRequiresSignIn = !isDemoIModel(props.iModelIdentifier);
+  const iModelRequiresSignIn = !isDemoIModel(iModelIdentifier);
   if (iModelRequiresSignIn && state === AuthorizationState.Offline) {
     return (
       <LandingPage headline="Cannot open this iModel while in offline mode">
@@ -80,5 +101,45 @@ export function OpenITwinIModel(props: OpenITwinIModelProps): React.ReactElement
       backendApiPromise: props.iTwinJsApp.backendApiPromise,
       iModelIdentifier,
     }
+  );
+}
+
+function usePopulateHeaderBreadcrumbs(iModelIdentifier: ITwinIModelIdentifier, user: User | undefined): void {
+  const { setBreadcrumbs } = React.useContext(appLayoutContext);
+  React.useEffect(
+    () => {
+      let disposed = false;
+      const demoIModel = demoIModels.get(iModelIdentifier.iModelId);
+      if (demoIModel) {
+        setBreadcrumbs([
+          <HeaderButton key="iTwin" name="Demo iModels" />,
+          <HeaderButton key="iModel" name={demoIModel.name} />,
+        ]);
+      } else if (user !== undefined) {
+        void (async () => {
+
+          const [project, iModel] = await Promise.all([
+            getProject(iModelIdentifier.iTwinId, user),
+            getIModel(iModelIdentifier.iModelId, user),
+          ]);
+          if (!disposed) {
+            setBreadcrumbs([
+              <HeaderButton
+                key="iTwin"
+                name={project.displayName}
+                description={project.projectNumber !== project.displayName ? project.projectNumber : undefined}
+              />,
+              <HeaderButton key="iModel" name={iModel.name} description={iModel.description} />,
+            ]);
+          }
+        })();
+      }
+
+      return () => {
+        disposed = true;
+        setBreadcrumbs([]);
+      };
+    },
+    [iModelIdentifier, setBreadcrumbs, user],
   );
 }


### PR DESCRIPTION
Whenever an iModel is opened, we now display its name and the project it's from in the app header. Snapshot iModels and demo iModels are treated as special cases and display some custom project information.

![image](https://user-images.githubusercontent.com/70327485/161703993-e2a68d1f-d708-4fdf-8e12-4600928f9bc3.png)

The header buttons are not made interactive yet.
