### PR TITLE
Attempt to silently renew auth token upon expiration

### DIFF
--- a/app/frontend/src/app/Authorization.tsx
+++ b/app/frontend/src/app/Authorization.tsx
@@ -36,6 +36,14 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
     // eslint-disable-next-line no-console
     console.warn(error);
   });
+  userManager.events.addAccessTokenExpiring(async () => {
+    try {
+      await userManager.signinSilent();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Silent sign in failed: ${error}`);
+    }
+  });
 
   const signIn = async () => {
     await userManager.signinRedirect({


### PR DESCRIPTION
The application will now attempt to silently sign in when auth token is almost expired.

When the user signs out elsewhere or the session expires, the silent sign in will fail and user will not be prompted to sign in. More future work still needs to be done in this area.