### PR TITLE
Implement iModel search

### DIFF
--- a/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
@@ -4,28 +4,46 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { AuthorizationClient } from "@itwin/core-common";
+import { SvgImodelHollow } from "@itwin/itwinui-icons-react";
 import { FluidGrid } from "@itwin/itwinui-layouts-react";
+import { Title } from "@itwin/itwinui-react";
 import { useAuthorization } from "../Authorization";
+import { VerticalStack } from "../common/CenteredStack";
 import { getIModel } from "../ITwinApi";
 import { demoIModels } from "../ITwinJsApp/IModelIdentifier";
-import { IModelTile } from "./IModelBrowser";
+import { iModelBrowserContext, IModelTile } from "./IModelBrowser";
 
 export function DemoIModelBrowser(): React.ReactElement {
   const { demoAuthorizationClient } = useAuthorization();
   const { demoIModelData, loadIModelData } = useDemoIModelData(demoAuthorizationClient);
+  let { searchQuery } = React.useContext(iModelBrowserContext);
+  searchQuery = searchQuery.trim().toLowerCase();
+  const iModels = [...demoIModels.entries()]
+    .filter(([_, { name }]) => searchQuery === "" || name.toLowerCase().includes(searchQuery));
+  if (iModels.length === 0) {
+    return (
+      <VerticalStack className="imodel-browser-no-data">
+        <SvgImodelHollow />
+        <Title isMuted>No iModels match given search query</Title>
+      </VerticalStack>
+    );
+  }
+
   return (
     <FluidGrid>
-      {[...demoIModels.entries()].map(([iModelId, { name, iTwinId }]) => (
-        <IModelTile
-          key={iModelId}
-          iModelId={iModelId}
-          iTwinId={iTwinId}
-          name={name}
-          description={demoIModelData.get(iModelId)?.description}
-          authorizationClient={demoAuthorizationClient}
-          onVisible={() => demoIModelData.get(iModelId) === undefined && loadIModelData(iModelId)}
-        />
-      ))}
+      {
+        iModels.map(([iModelId, { name, iTwinId }]) => (
+          <IModelTile
+            key={iModelId}
+            iModelId={iModelId}
+            iTwinId={iTwinId}
+            name={name}
+            description={demoIModelData.get(iModelId)?.description}
+            authorizationClient={demoAuthorizationClient}
+            onVisible={() => demoIModelData.get(iModelId) === undefined && loadIModelData(iModelId)}
+          />
+        ))
+      }
     </FluidGrid>
   );
 }

--- a/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
@@ -33,8 +33,17 @@ export const IModelBrowser = React.memo(
     const backendApi = useBackendApi(props.backendApiPromise);
     React.useEffect(() => () => intersectionObserver.dispose(), [intersectionObserver]);
     const match = useMatch("/browse-imodels/:tab");
+    const [searchQuery, setSearchQuery] = React.useState("");
+    const clearSearchQuery = React.useRef(() => setSearchQuery("")).current;
     return (
-      <iModelBrowserContext.Provider value={{ displayMode: settings.displayMode, intersectionObserver }}>
+      <iModelBrowserContext.Provider
+        value={{
+          displayMode: settings.displayMode,
+          intersectionObserver,
+          searchQuery,
+          clearSearchQuery,
+        }}
+      >
         <AppSideNavigation activePage={AppPage.iModelBrowser} />
         <PageLayout.Content padded>
           <Headline>Browse iModels</Headline>
@@ -69,7 +78,14 @@ export const IModelBrowser = React.memo(
                 <Title>All</Title>
                 <Grid>
                   <Grid.Item className="imodel-browser-controls" columnSpan={12}>
-                    <LabeledInput placeholder="Search" svgIcon={<SvgSearch />} iconDisplayStyle="inline" />
+                    <LabeledInput
+                      placeholder="Search"
+                      svgIcon={<SvgSearch />}
+                      iconDisplayStyle="inline"
+                      value={searchQuery}
+                      maxLength={255}
+                      onChange={(event) => setSearchQuery(event.target.value)}
+                    />
                     {
                       match?.params.tab !== "demo" &&
                       <ButtonGroup>
@@ -140,11 +156,15 @@ function PaddedSurface(props: PaddedSurfaceProps): React.ReactElement {
 export interface IModelBrowserContext {
   displayMode: "grid" | "list";
   intersectionObserver: ViewportIntersectionObserver | undefined;
+  searchQuery: string;
+  clearSearchQuery: () => void;
 }
 
 export const iModelBrowserContext = React.createContext<IModelBrowserContext>({
   displayMode: "grid",
   intersectionObserver: undefined,
+  searchQuery: "",
+  clearSearchQuery: () => {},
 });
 
 export interface IModelBrowserTabsProps {

--- a/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
@@ -7,9 +7,9 @@ import { useNavigate, useParams } from "react-router-dom";
 import { CellProps } from "react-table";
 import { assert } from "@itwin/core-bentley";
 import { AuthorizationClient } from "@itwin/core-common";
-import { SvgProject } from "@itwin/itwinui-icons-react";
+import { SvgImodelHollow, SvgProject } from "@itwin/itwinui-icons-react";
 import { FluidGrid } from "@itwin/itwinui-layouts-react";
-import { Anchor, Button, Table, TableProps, Tile } from "@itwin/itwinui-react";
+import { Anchor, Button, Table, TableProps, Tile, Title } from "@itwin/itwinui-react";
 import { appNavigationContext } from "../AppContext";
 import { AuthorizationState, useAuthorization } from "../Authorization";
 import { HorizontalStack, VerticalStack } from "../common/CenteredStack";
@@ -21,24 +21,23 @@ import { iModelBrowserContext, IModelTile } from "./IModelBrowser";
 export function ITwinBrowser(): React.ReactElement {
   const { userAuthorizationClient, state, signIn } = useAuthorization();
   const [iTwins, setITwins] = React.useState<ProjectRepresentation[]>();
-  const { displayMode } = React.useContext(iModelBrowserContext);
-  React.useEffect(
-    () => {
+  const { displayMode, searchQuery } = React.useContext(iModelBrowserContext);
+
+  React.useEffect(() => setITwins(undefined), [userAuthorizationClient, searchQuery]);
+
+  useDebouncedAsyncEffect(
+    async (disposedRef) => {
       if (userAuthorizationClient === undefined) {
         return;
       }
 
-      let disposed = false;
-      void (async () => {
-        const response = await getUserProjects("representation", userAuthorizationClient);
-        if (!disposed && response) {
-          setITwins(response.sort((a, b) => Date.parse(b.registrationDateTime) - Date.parse(a.registrationDateTime)));
-        }
-      })();
-
-      return () => { disposed = true; };
+      const response = await getUserProjects("representation", userAuthorizationClient, searchQuery);
+      if (!disposedRef.current && response) {
+        setITwins(response.sort((a, b) => Date.parse(b.registrationDateTime) - Date.parse(a.registrationDateTime)));
+      }
     },
-    [userAuthorizationClient],
+    [userAuthorizationClient, searchQuery],
+    500,
   );
 
   if (state === AuthorizationState.SignedOut) {
@@ -54,6 +53,15 @@ export function ITwinBrowser(): React.ReactElement {
     return (
       <VerticalStack>
         <HorizontalStack>Projects are unavailable in offline mode. <OfflineModeExplainer /></HorizontalStack>
+      </VerticalStack>
+    );
+  }
+
+  if (iTwins?.length === 0) {
+    return (
+      <VerticalStack className="imodel-browser-no-data">
+        <SvgProject />
+        <Title isMuted>{searchQuery ? "No projects match given search query" : "No projects found"}</Title>
       </VerticalStack>
     );
   }
@@ -75,17 +83,20 @@ function ITwinBrowserGridView(props: ITwinBrowserGridViewProps): React.ReactElem
 
   return (
     <FluidGrid>
-      {props.iTwins.map((iTwin) => (
-        <Tile
-          key={iTwin.id}
-          name={iTwin.displayName}
-          variant="folder"
-          isActionable
-          thumbnail={<SvgProject />}
-          description={iTwin.projectNumber}
-          onClick={() => navigate(iTwin.id)}
-        />
-      ))}
+      {
+        props.iTwins.map((iTwin) => (
+          <div key={iTwin.id}>
+            <Tile
+              name={iTwin.displayName}
+              variant="folder"
+              isActionable
+              thumbnail={<SvgProject />}
+              description={iTwin.projectNumber}
+              onClick={() => navigate(iTwin.id)}
+            />
+          </div>
+        ))
+      }
     </FluidGrid>
   );
 }
@@ -128,25 +139,35 @@ export function ITwinIModelBrowser(): React.ReactElement {
 
   const { userAuthorizationClient } = useAuthorization();
   const [iModels, setIModels] = React.useState<IModelRepresentation[]>();
-  const { displayMode } = React.useContext(iModelBrowserContext);
-  React.useEffect(
-    () => {
+  const { displayMode, searchQuery, clearSearchQuery } = React.useContext(iModelBrowserContext);
+
+  // We do not want to inherit search query that was intended for iTwins
+  React.useEffect(() => clearSearchQuery(), [clearSearchQuery]);
+  React.useEffect(() => setIModels(undefined), [userAuthorizationClient, iTwin, searchQuery]);
+
+  useDebouncedAsyncEffect(
+    async (disposedRef) => {
       if (userAuthorizationClient === undefined) {
         return;
       }
 
-      let disposed = false;
-      void (async () => {
-        const response = await getProjectIModels(iTwin, "representation", userAuthorizationClient);
-        if (!disposed && response) {
-          setIModels(response.sort((a, b) => Date.parse(b.createdDateTime) - Date.parse(a.createdDateTime)));
-        }
-      })();
-
-      return () => { disposed = true; };
+      const response = await getProjectIModels(iTwin, "representation", userAuthorizationClient, searchQuery);
+      if (!disposedRef.current && response) {
+        setIModels(response.sort((a, b) => Date.parse(b.createdDateTime) - Date.parse(a.createdDateTime)));
+      }
     },
-    [userAuthorizationClient, iTwin],
+    [userAuthorizationClient, iTwin, searchQuery],
+    500,
   );
+
+  if (iModels?.length === 0) {
+    return (
+      <VerticalStack className="imodel-browser-no-data">
+        <SvgImodelHollow />
+        <Title isMuted>No iModels match search query exactly</Title>
+      </VerticalStack>
+    );
+  }
 
   return displayMode === "grid"
     ? <IModelBrowserGridView iModels={iModels} authorizationClient={userAuthorizationClient} />
@@ -214,4 +235,40 @@ function IModelBrowserTableView(props: IModelBrowserTableViewProps): React.React
     dateCreated: new Date(iModel.createdDateTime).toLocaleDateString(),
   }));
   return <Table columns={columns} data={tableData ?? []} isLoading={tableData === undefined} emptyTableContent="" />;
+}
+
+function useDebouncedAsyncEffect(
+  effect: (disposedRef: { current: boolean }) => Promise<void>,
+  dependencies: unknown[],
+  cooldownMilliseconds: number,
+): void {
+  const activeEffectRef = React.useRef(Promise.resolve());
+
+  React.useEffect(
+    () => {
+      const disposedRef = { current: false };
+      let timeout: any;
+      void (async () => {
+        await activeEffectRef.current;
+        if (disposedRef.current) {
+          return;
+        }
+
+        timeout = setTimeout(
+          () => {
+            if (!disposedRef.current) {
+              activeEffectRef.current = effect(disposedRef);
+            }
+          },
+          cooldownMilliseconds,
+        );
+      })();
+      return () => {
+        disposedRef.current = true;
+        clearTimeout(timeout);
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    dependencies,
+  );
 }

--- a/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
@@ -164,7 +164,9 @@ export function ITwinIModelBrowser(): React.ReactElement {
     return (
       <VerticalStack className="imodel-browser-no-data">
         <SvgImodelHollow />
-        <Title isMuted>No iModels match search query exactly</Title>
+        <Title isMuted>
+          {searchQuery ? "No iModels match search query exactly" : "No iModels found in this iTwin"}
+        </Title>
       </VerticalStack>
     );
   }

--- a/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
@@ -28,7 +28,7 @@ export function LocalIModelBrowser(props: LocalIModelBrowserProps): React.ReactE
       <VerticalStack className="imodel-browser-no-data">
         <SvgImodelHollow />
         <Title isMuted>
-          {searchQuery.length > 0 ? "No local iModels match search query" : "No local iModel snapshots found"}
+          {searchQuery ? "No local iModels match search query" : "No local iModel snapshots found"}
         </Title>
         <AsyncActionButton onClick={async () => backendApi?.openIModelsDirectory()}>
           Open snapshots folder

--- a/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
@@ -21,14 +21,15 @@ export interface LocalIModelBrowserProps {
 
 export function LocalIModelBrowser(props: LocalIModelBrowserProps): React.ReactElement {
   const backendApi = useBackendApi(props.backendApiPromise);
-  const availableIModels = useAvailableIModels(backendApi);
-  const { displayMode } = React.useContext(iModelBrowserContext);
-
+  const { displayMode, searchQuery } = React.useContext(iModelBrowserContext);
+  const availableIModels = useAvailableIModels(backendApi, searchQuery);
   if (availableIModels?.length === 0) {
     return (
       <VerticalStack className="imodel-browser-no-data">
         <SvgImodelHollow />
-        <Title isMuted>No local iModel snapshots found</Title>
+        <Title isMuted>
+          {searchQuery.length > 0 ? "No local iModels match search query" : "No local iModel snapshots found"}
+        </Title>
         <AsyncActionButton onClick={async () => backendApi?.openIModelsDirectory()}>
           Open snapshots folder
         </AsyncActionButton>
@@ -43,7 +44,7 @@ export function LocalIModelBrowser(props: LocalIModelBrowserProps): React.ReactE
     : <TableView availableIModels={availableIModels} openSnapshotsFolder={openSnapshotsFolder} />;
 }
 
-function useAvailableIModels(backendApi: BackendApi | undefined): IModelMetadata[] | undefined {
+function useAvailableIModels(backendApi: BackendApi | undefined, searchQuery: string): IModelMetadata[] | undefined {
   const [availableIModels, setAvailableIModels] = React.useState<IModelMetadata[]>();
   React.useEffect(
     () => {
@@ -60,7 +61,8 @@ function useAvailableIModels(backendApi: BackendApi | undefined): IModelMetadata
     [backendApi],
   );
 
-  return availableIModels;
+  searchQuery = searchQuery.trim().toLowerCase();
+  return availableIModels?.filter(({ name }) => searchQuery === "" || name.toLowerCase().includes(searchQuery));
 }
 
 interface GridViewProps {

--- a/app/frontend/src/app/ITwinApi.ts
+++ b/app/frontend/src/app/ITwinApi.ts
@@ -27,16 +27,22 @@ export type ProjectMinimal = Pick<ProjectRepresentation, "id" | "displayName" | 
 export async function getUserProjects(
   detail: "minimal",
   authorizationClient: AuthorizationClient,
+  search?: string,
 ): Promise<ProjectMinimal[] | undefined>;
 export async function getUserProjects(
   detail: "representation",
   authorizationClient: AuthorizationClient,
+  search?: string,
 ): Promise<ProjectRepresentation[] | undefined>;
 export async function getUserProjects(
   detail: "minimal" | "representation",
   authorizationClient: AuthorizationClient,
+  search?: string,
 ): Promise<ProjectMinimal[] | ProjectRepresentation[] | undefined> {
-  const response = await callITwinApi(`projects`, authorizationClient, { Prefer: `return=${detail}` });
+  // Search query should contain non-whitespace characters and not exceed 255 characters.
+  search = search?.trim().slice(0, 256);
+  const searchQuery = search ? `?$search=${search}` : "";
+  const response = await callITwinApi(`projects${searchQuery}`, authorizationClient, { Prefer: `return=${detail}` });
   if (!response.ok) {
     return;
   }
@@ -84,19 +90,25 @@ export async function getProjectIModels(
   projectId: string,
   detail: "minimal",
   authorizationClient: AuthorizationClient,
+  name?: string,
 ): Promise<IModelMinimal[] | undefined>;
 export async function getProjectIModels(
   projectId: string,
   detail: "representation",
   authorizationClient: AuthorizationClient,
+  name?: string,
 ): Promise<IModelRepresentation[] | undefined>;
 export async function getProjectIModels(
   projectId: string,
   detail: "minimal" | "representation",
   authorizationClient: AuthorizationClient,
+  name?: string,
 ): Promise<IModelMinimal[] | IModelRepresentation[] | undefined> {
+  // Search query should contain non-whitespace characters and not exceed 255 characters.
+  name = name?.trim().slice(0, 256);
+  const nameQuery = name ? `&name=${name}` : "";
   const response = await callITwinApi(
-    `imodels?projectId=${projectId}`,
+    `imodels?projectId=${projectId}${nameQuery}`,
     authorizationClient,
     { Prefer: `return=${detail}` },
   );


### PR DESCRIPTION
Enables searching functionality in the iModel browser.

iTwin APIs provide ability to search iModels only by querying the exact iModel name. All other searches do not have such limitation and are case-insensitive and allow partial matches.