### PR TITLE
Fix duplicate entries in recent iModels browser

### DIFF
--- a/app/frontend/src/app/ITwinJsApp/IModelIdentifier.tsx
+++ b/app/frontend/src/app/ITwinJsApp/IModelIdentifier.tsx
@@ -12,16 +12,24 @@ export interface ITwinIModelIdentifier {
 }
 
 export function isIModelIdentifier(identifier: unknown): identifier is IModelIdentifier {
-  return typeof identifier === "string"
-    || (typeof identifier === "object" && !!identifier && "iTwinId" in identifier && "iModelId" in identifier);
+  return isSnapshotIModel(identifier) || isITwinIModel(identifier);
 }
 
-export function isSnapshotIModel(identifier: IModelIdentifier): identifier is SnapshotIModelIdentifier {
+export function isSnapshotIModel(identifier: unknown): identifier is SnapshotIModelIdentifier {
   return typeof identifier === "string";
+}
+
+export function isITwinIModel(identifier: unknown): identifier is ITwinIModelIdentifier {
+  return !!identifier && typeof identifier === "object" && "iTwinId" in identifier && "iModelId" in identifier;
 }
 
 export function isDemoIModel(identifier: IModelIdentifier): boolean {
   return !isSnapshotIModel(identifier) && demoIModels.get(identifier.iModelId)?.iTwinId === identifier.iTwinId;
+}
+
+export function areIModelIdentifiersEqual(a: IModelIdentifier, b: IModelIdentifier): boolean {
+  return (isSnapshotIModel(a) && a === b)
+    || (isITwinIModel(a) && isITwinIModel(b) && a.iTwinId === b.iTwinId && a.iModelId === b.iModelId);
 }
 
 export const demoIModels = new Map([

--- a/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
@@ -14,7 +14,7 @@ import { EditableRuleset, SoloRulesetEditor } from "@itwin/presentation-rules-ed
 import { useIModelBrowserSettings } from "../IModelBrowser/IModelBrowser";
 import { BackendApi } from "./api/BackendApi";
 import { ContentTabs } from "./content-tabs/ContentTabs";
-import { IModelIdentifier, isSnapshotIModel } from "./IModelIdentifier";
+import { areIModelIdentifiersEqual, IModelIdentifier, isSnapshotIModel } from "./IModelIdentifier";
 import { backendApiContext, rulesetEditorContext, RulesetEditorTab } from "./ITwinJsAppContext";
 import { parseEditorState } from "./misc/EditorStateSerializer";
 import { displayToast } from "./misc/Notifications";
@@ -163,7 +163,9 @@ function useRecentIModels(): (iModelIdentifer: IModelIdentifier) => void {
   const [_, setRecentIModels] = useIModelBrowserSettings();
   return React.useRef((iModelIdentifier: IModelIdentifier) => {
     setRecentIModels((prevState) => {
-      const newRecentIModels = prevState.recentIModels.filter((value) => value !== iModelIdentifier);
+      const newRecentIModels = prevState.recentIModels.filter(
+        (value) => !areIModelIdentifiersEqual(value, iModelIdentifier),
+      );
       newRecentIModels.push(iModelIdentifier);
       return { ...prevState, recentIModels: newRecentIModels.slice(-10) };
     });


### PR DESCRIPTION
Each time user opens an iModel, a corresponding entry is added to the recent iModels array. The check for duplicate identifiers wasn't working correctly for non-snapshot iModels, and this resulted in duplicate entries being shown in the recent iModels browser.

This PR fixes duplicate non-snapshot iModel filtering so that we do not save any iModel identifiers more than once.

This bug affects all users in dev- and qa- environments. They will need to clear their local storage to remove the duplicate entries, or open 10 different iModels to cycle the duplicates out.