### PR TITLE
Upgrade TypeScript to 4.7.4

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -31,6 +31,6 @@
     "eslint": "^7.30.0",
     "pretty-bytes": "^5.6.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "~4.4.2"
+    "typescript": "^4.7.4"
   }
 }

--- a/app/common/package.json
+++ b/app/common/package.json
@@ -18,6 +18,6 @@
     "@itwin/eslint-plugin": "3.2.6",
     "@itwin/presentation-common": "3.2.6",
     "eslint": "^7.30.0",
-    "typescript": "~4.4.2"
+    "typescript": "^4.7.4"
   }
 }

--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -31,6 +31,6 @@
     "mocha-junit-reporter": "^2.0.2",
     "playwright": "^1.14.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.4.2"
+    "typescript": "^4.7.4"
   }
 }

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^16.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-redux": "^7.1.24",
     "@types/react-table": "^7.7.12",
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^9.0.1",
@@ -81,7 +82,7 @@
     "timers-browserify": "^2.0.12",
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
-    "typescript": "~4.4.2",
+    "typescript": "^4.7.4",
     "webpack": "^5.51.1",
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.7.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
       eslint: ^7.30.0
       pretty-bytes: ^5.6.0
       ts-node-dev: ^2.0.0
-      typescript: ~4.4.2
+      typescript: ^4.7.4
     dependencies:
       '@app/common': link:../common
       '@itwin/core-backend': 3.2.6_6ohybkq4kqst3ov2dvwshk734e
@@ -38,7 +38,7 @@ importers:
       '@itwin/core-geometry': 3.2.6
       '@itwin/core-quantity': 3.2.6_@itwin+core-bentley@3.2.6
       '@itwin/ecschema-metadata': 3.2.6_maaimb55y7nclfv77uw5xsg7fm
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@itwin/express-server': 3.2.6_@itwin+core-backend@3.2.6
       '@itwin/imodels-access-backend': 1.0.1_pwbwggfsl6ztjt7ln6trwxxex4
       '@itwin/presentation-backend': 3.2.6_6p5k6cflgn7exkzy3hl4r7woru
@@ -47,8 +47,8 @@ importers:
       dotenv: 10.0.0
       eslint: 7.32.0
       pretty-bytes: 5.6.0
-      ts-node-dev: 2.0.0_wdziywezassjgtpdt3uw4akqqi
-      typescript: 4.4.4
+      ts-node-dev: 2.0.0_nffhatmfv277bvws7shomq2g3e
+      typescript: 4.7.4
 
   app/common:
     specifiers:
@@ -59,16 +59,16 @@ importers:
       '@itwin/eslint-plugin': 3.2.6
       '@itwin/presentation-common': 3.2.6
       eslint: ^7.30.0
-      typescript: ~4.4.2
+      typescript: ^4.7.4
     dependencies:
       '@itwin/core-bentley': 3.2.6
       '@itwin/core-common': 3.2.6_6kouksveek4dijdazf2hfz4uz4
       '@itwin/core-geometry': 3.2.6
       '@itwin/core-quantity': 3.2.6_@itwin+core-bentley@3.2.6
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@itwin/presentation-common': 3.2.6_jz7ayrdprijj6f6ltjg5r5n2kq
       eslint: 7.32.0
-      typescript: 4.4.4
+      typescript: 4.7.4
 
   app/e2e-tests:
     specifiers:
@@ -85,9 +85,9 @@ importers:
       mocha-junit-reporter: ^2.0.2
       playwright: ^1.14.0
       ts-node: ^10.9.1
-      typescript: ~4.4.2
+      typescript: ^4.7.4
     dependencies:
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@types/chai': 4.3.0
       '@types/jest-dev-server': 5.0.0
       '@types/mocha': 9.1.0
@@ -99,8 +99,8 @@ importers:
       mocha: 9.2.1
       mocha-junit-reporter: 2.0.2_mocha@9.2.1
       playwright: 1.19.1
-      ts-node: 10.9.1_wdziywezassjgtpdt3uw4akqqi
-      typescript: 4.4.4
+      ts-node: 10.9.1_nffhatmfv277bvws7shomq2g3e
+      typescript: 4.7.4
 
   app/frontend:
     specifiers:
@@ -139,6 +139,7 @@ importers:
       '@types/node': ^16.0.0
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
+      '@types/react-redux': ^7.1.24
       '@types/react-table': ^7.7.12
       buffer: ^6.0.3
       copy-webpack-plugin: ^9.0.1
@@ -170,7 +171,7 @@ importers:
       timers-browserify: ^2.0.12
       ts-node: ^10.9.1
       tslib: ^2.3.1
-      typescript: ~4.4.2
+      typescript: ^4.7.4
       webpack: ^5.51.1
       webpack-cli: ^4.8.0
       webpack-dev-server: ^4.7.4
@@ -189,7 +190,7 @@ importers:
       '@itwin/core-orbitgt': 3.2.6
       '@itwin/core-quantity': 3.2.6_@itwin+core-bentley@3.2.6
       '@itwin/core-react': 3.2.6_bc6mwbttqb24rkftacaleky3um
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@itwin/imodel-browser-react': 0.12.2_sfoxds7t5ydpegc3knd667wn6m
       '@itwin/imodel-components-react': 3.2.6_r46ij5jeqf3voy4ts5pucpaqg4
       '@itwin/imodels-access-frontend': 1.0.1_5w62jzbzztetijw63gzvdvccuq
@@ -210,6 +211,7 @@ importers:
       '@types/node': 16.11.46
       '@types/react': 17.0.39
       '@types/react-dom': 17.0.11
+      '@types/react-redux': 7.1.24
       '@types/react-table': 7.7.12
       buffer: 6.0.3
       copy-webpack-plugin: 9.1.0_webpack@5.69.1
@@ -239,9 +241,9 @@ importers:
       style-loader: 2.0.0_webpack@5.69.1
       terser-webpack-plugin: 5.3.1_webpack@5.69.1
       timers-browserify: 2.0.12
-      ts-node: 10.9.1_wdziywezassjgtpdt3uw4akqqi
+      ts-node: 10.9.1_nffhatmfv277bvws7shomq2g3e
       tslib: 2.3.1
-      typescript: 4.4.4
+      typescript: 4.7.4
       webpack: 5.69.1_webpack-cli@4.9.2
       webpack-cli: 4.9.2_k3ju362ue7tn6rncplru7hrmxi
       webpack-dev-server: 4.7.4_h44w3yazp4pjdj4mvlxirvmede
@@ -290,7 +292,7 @@ importers:
       sinon: ^10.0.0
       sinon-chai: ^3.7.0
       ts-node: ^10.9.1
-      typescript: ~4.4.2
+      typescript: ^4.7.4
     dependencies:
       '@itwin/itwinui-react': 1.40.1_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
@@ -304,7 +306,7 @@ importers:
       '@itwin/core-orbitgt': 3.2.6
       '@itwin/core-quantity': 3.2.6_@itwin+core-bentley@3.2.6
       '@itwin/core-react': 3.2.6_bc6mwbttqb24rkftacaleky3um
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@itwin/imodel-components-react': 3.2.6_r46ij5jeqf3voy4ts5pucpaqg4
       '@itwin/presentation-common': 3.2.6_jz7ayrdprijj6f6ltjg5r5n2kq
       '@itwin/presentation-components': 3.2.6_jran2ahb6glwbsfxfsnavkn4hm
@@ -334,29 +336,31 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       sinon: 10.0.0
       sinon-chai: 3.7.0_chai@4.3.6+sinon@10.0.0
-      ts-node: 10.9.1_wdziywezassjgtpdt3uw4akqqi
-      typescript: 4.4.4
+      ts-node: 10.9.1_nffhatmfv277bvws7shomq2g3e
+      typescript: 4.7.4
 
   scripts:
     specifiers:
       '@itwin/eslint-plugin': 3.2.6
       '@types/node': ^16.0.0
       '@types/rimraf': ^3.0.0
+      '@types/yargs': ^17.0.11
       eslint: ^7.30.0
       npm-run-all: ^4.1.5
       rimraf: ^3.0.2
       ts-node: ^10.9.1
-      typescript: ~4.4.2
+      typescript: ^4.7.4
       yargs: ^17.0.1
     dependencies:
-      '@itwin/eslint-plugin': 3.2.6_wnilx7boviscikmvsfkd6ljepe
+      '@itwin/eslint-plugin': 3.2.6_hxadhbs2xogijvk7vq4t2azzbu
       '@types/node': 16.11.46
       '@types/rimraf': 3.0.2
+      '@types/yargs': 17.0.11
       eslint: 7.32.0
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      ts-node: 10.9.1_wdziywezassjgtpdt3uw4akqqi
-      typescript: 4.4.4
+      ts-node: 10.9.1_nffhatmfv277bvws7shomq2g3e
+      typescript: 4.7.4
       yargs: 17.3.1
 
 packages:
@@ -1117,19 +1121,19 @@ packages:
       almost-equal: 1.1.0
     dev: false
 
-  /@itwin/eslint-plugin/3.2.6_wnilx7boviscikmvsfkd6ljepe:
+  /@itwin/eslint-plugin/3.2.6_hxadhbs2xogijvk7vq4t2azzbu:
     resolution: {integrity: sha512-ooz3sJFOz2znlMNtIzkiOvSeLUwOdbdatiGF4Qr8oP9TJ3ZoXz6wSaxJ+SuNwTRdys8nnAfouqnlkXVJgvyBRA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_r4cbnkuoywfengijyxapomdjxq
-      '@typescript-eslint/parser': 4.31.2_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/eslint-plugin': 4.31.2_mqb35fu623hl2em5dqydrwbeu4
+      '@typescript-eslint/parser': 4.31.2_hxadhbs2xogijvk7vq4t2azzbu
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.4.0_5yw5wetchsmfynrjb6mfvvkvtq
-      eslint-plugin-deprecation: 1.2.1_wnilx7boviscikmvsfkd6ljepe
+      eslint-plugin-deprecation: 1.2.1_hxadhbs2xogijvk7vq4t2azzbu
       eslint-plugin-import: 2.23.4_5gi2uhek3vtoxuuofzzywxb6ty
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
@@ -1138,7 +1142,7 @@ packages:
       eslint-plugin-react: 7.24.0_eslint@7.32.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.32.0
       require-dir: 1.2.0
-      typescript: 4.4.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -1914,8 +1918,8 @@ packages:
       '@types/react': 17.0.39
     dev: false
 
-  /@types/react-redux/7.1.22:
-    resolution: {integrity: sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==}
+  /@types/react-redux/7.1.24:
+    resolution: {integrity: sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 17.0.39
@@ -2027,13 +2031,18 @@ packages:
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
-    dev: true
 
   /@types/yargs/15.0.14:
     resolution: {integrity: sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==}
     dependencies:
       '@types/yargs-parser': 20.2.1
     dev: true
+
+  /@types/yargs/17.0.11:
+    resolution: {integrity: sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==}
+    dependencies:
+      '@types/yargs-parser': 20.2.1
+    dev: false
 
   /@types/yauzl/2.9.2:
     resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
@@ -2043,7 +2052,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/4.31.2_r4cbnkuoywfengijyxapomdjxq:
+  /@typescript-eslint/eslint-plugin/4.31.2_mqb35fu623hl2em5dqydrwbeu4:
     resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2054,20 +2063,20 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.31.2_wnilx7boviscikmvsfkd6ljepe
-      '@typescript-eslint/parser': 4.31.2_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/experimental-utils': 4.31.2_hxadhbs2xogijvk7vq4t2azzbu
+      '@typescript-eslint/parser': 4.31.2_hxadhbs2xogijvk7vq4t2azzbu
       '@typescript-eslint/scope-manager': 4.31.2
       debug: 4.3.3
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.4.4
-      typescript: 4.4.4
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils/3.10.1_wnilx7boviscikmvsfkd6ljepe:
+  /@typescript-eslint/experimental-utils/3.10.1_hxadhbs2xogijvk7vq4t2azzbu:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2075,7 +2084,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.4.4
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.7.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -2083,7 +2092,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/experimental-utils/4.31.2_wnilx7boviscikmvsfkd6ljepe:
+  /@typescript-eslint/experimental-utils/4.31.2_hxadhbs2xogijvk7vq4t2azzbu:
     resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2092,7 +2101,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.7.4
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -2100,7 +2109,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/parser/4.31.2_wnilx7boviscikmvsfkd6ljepe:
+  /@typescript-eslint/parser/4.31.2_hxadhbs2xogijvk7vq4t2azzbu:
     resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2112,10 +2121,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.31.2
       '@typescript-eslint/types': 4.31.2
-      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.4.4
+      '@typescript-eslint/typescript-estree': 4.31.2_typescript@4.7.4
       debug: 4.3.3
       eslint: 7.32.0
-      typescript: 4.4.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2134,7 +2143,7 @@ packages:
     resolution: {integrity: sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
 
-  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.4.4:
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.7.4:
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2150,12 +2159,12 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.4.4
-      typescript: 4.4.4
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.4.4:
+  /@typescript-eslint/typescript-estree/4.31.2_typescript@4.7.4:
     resolution: {integrity: sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2170,8 +2179,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.4.4
-      typescript: 4.4.4
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -3891,7 +3900,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.31.2_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/parser': 4.31.2_hxadhbs2xogijvk7vq4t2azzbu
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.4.0_5yw5wetchsmfynrjb6mfvvkvtq
@@ -3899,17 +3908,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-deprecation/1.2.1_wnilx7boviscikmvsfkd6ljepe:
+  /eslint-plugin-deprecation/1.2.1_hxadhbs2xogijvk7vq4t2azzbu:
     resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
       typescript: ^3.7.5 || ^4.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/experimental-utils': 3.10.1_hxadhbs2xogijvk7vq4t2azzbu
       eslint: 7.32.0
       tslib: 1.14.1
-      tsutils: 3.21.0_typescript@4.4.4
-      typescript: 4.4.4
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -3923,7 +3932,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.31.2_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/parser': 4.31.2_hxadhbs2xogijvk7vq4t2azzbu
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
@@ -6692,7 +6701,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.17.2
-      '@types/react-redux': 7.1.22
+      '@types/react-redux': 7.1.24
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -7722,7 +7731,7 @@ packages:
   /ts-key-enum/2.0.10:
     resolution: {integrity: sha512-gqbZa/AlFKwDjS4fCVmsNsQNeVz+eUrAgn+Pk/WluAeeuDljwr6CH5zMZgB6lWoFVkA8+ie9mjEPX+ET1aLQ5g==}
 
-  /ts-node-dev/2.0.0_wdziywezassjgtpdt3uw4akqqi:
+  /ts-node-dev/2.0.0_nffhatmfv277bvws7shomq2g3e:
     resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
     engines: {node: '>=0.8.0'}
     hasBin: true
@@ -7741,16 +7750,16 @@ packages:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.1_wdziywezassjgtpdt3uw4akqqi
+      ts-node: 10.9.1_nffhatmfv277bvws7shomq2g3e
       tsconfig: 7.0.0
-      typescript: 4.4.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
     dev: false
 
-  /ts-node/10.9.1_wdziywezassjgtpdt3uw4akqqi:
+  /ts-node/10.9.1_nffhatmfv277bvws7shomq2g3e:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -7776,7 +7785,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.4.4
+      typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7803,14 +7812,14 @@ packages:
   /tslib/2.3.1:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
 
-  /tsutils/3.21.0_typescript@4.4.4:
+  /tsutils/3.21.0_typescript@4.7.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.4.4
+      typescript: 4.7.4
 
   /tunnel/0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -7857,8 +7866,8 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript/4.4.4:
-    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 

--- a/presentation-rules-editor-react/package.json
+++ b/presentation-rules-editor-react/package.json
@@ -110,6 +110,6 @@
     "sinon": "^10.0.0",
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.4.2"
+    "typescript": "^4.7.4"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,11 +17,12 @@
     "@itwin/eslint-plugin": "3.2.6",
     "@types/node": "^16.0.0",
     "@types/rimraf": "^3.0.0",
+    "@types/yargs": "^17.0.11",
     "eslint": "^7.30.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.4.2",
+    "typescript": "^4.7.4",
     "yargs": "^17.0.1"
   }
 }

--- a/scripts/src/linkIModeljsRepo.ts
+++ b/scripts/src/linkIModeljsRepo.ts
@@ -18,7 +18,7 @@ const packagesToLink = new Set([
 
 const repositoryRootLocation = getRepositoryRootLocation();
 
-const args = yargs(process.argv.slice(2))
+const args: any = yargs(process.argv.slice(2))
   .scriptName(path.basename(__filename))
   .command(
     "link [imodeljs_repo]",


### PR DESCRIPTION
The version of TypeScript that we used previously is old enough that type checking errors reported in CI are not surfaced by VSCode editor.