### PR TITLE
Fix bundle size regression

### DIFF
--- a/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
@@ -17,7 +17,7 @@ import { useAuthorization } from "../Authorization";
 import { VerticalStack } from "../common/CenteredStack";
 import { useLocalStorage } from "../common/LocalStorage";
 import { getIModel, getIModelThumbnail } from "../ITwinApi";
-import { BackendApi, useBackendApi } from "../ITwinJsApp/api/BackendApi";
+import { BackendApi } from "../ITwinJsApp/api/BackendApi";
 import {
   demoIModels, IModelIdentifier, isDemoIModel, isIModelIdentifier, isSnapshotIModel, ITwinIModelIdentifier,
 } from "../ITwinJsApp/IModelIdentifier";
@@ -383,4 +383,24 @@ export function useIModelBrowserSettings(): [
       return { displayMode, recentIModels };
     },
   );
+}
+
+export function useBackendApi(backendApiPromise: Promise<BackendApi> | undefined): BackendApi | undefined {
+  const [backendApi, setBackendApi] = React.useState<BackendApi>();
+  React.useEffect(
+    () => {
+      let disposed = false;
+      void (async () => {
+        const backendApiResult = await backendApiPromise;
+        if (!disposed) {
+          setBackendApi(backendApiResult);
+        }
+      })();
+
+      return () => { disposed = true; };
+    },
+    [backendApiPromise],
+  );
+
+  return backendApi;
 }

--- a/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/LocalIModelBrowser.tsx
@@ -11,9 +11,9 @@ import { Anchor, DropdownMenu, IconButton, MenuItem, Table, TableProps, Title } 
 import { appNavigationContext } from "../AppContext";
 import { AsyncActionButton } from "../common/AsyncActionButton";
 import { VerticalStack } from "../common/CenteredStack";
-import { BackendApi, useBackendApi } from "../ITwinJsApp/api/BackendApi";
+import { BackendApi } from "../ITwinJsApp/api/BackendApi";
 import { LoadingHint } from "../ITwinJsApp/common/LoadingHint";
-import { iModelBrowserContext, IModelSnapshotTile } from "./IModelBrowser";
+import { iModelBrowserContext, IModelSnapshotTile, useBackendApi } from "./IModelBrowser";
 
 export interface LocalIModelBrowserProps {
   backendApiPromise: Promise<BackendApi> | undefined;

--- a/app/frontend/src/app/ITwinJsApp/api/BackendApi.ts
+++ b/app/frontend/src/app/ITwinJsApp/api/BackendApi.ts
@@ -2,7 +2,6 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import * as React from "react";
 import { IModelMetadata, PresentationRulesEditorRpcInterface } from "@app/common";
 import { Guid, Id64, Id64String, Logger } from "@itwin/core-bentley";
 import { IModelVersion } from "@itwin/core-common";
@@ -55,24 +54,4 @@ export class BackendApi {
     const viewDefinitionProps = await imodel.views.queryProps({ wantPrivate: false, limit: 1 });
     return viewDefinitionProps[0].id ?? Id64.invalid;
   }
-}
-
-export function useBackendApi(backendApiPromise: Promise<BackendApi> | undefined): BackendApi | undefined {
-  const [backendApi, setBackendApi] = React.useState<BackendApi>();
-  React.useEffect(
-    () => {
-      let disposed = false;
-      void (async () => {
-        const backendApiResult = await backendApiPromise;
-        if (!disposed) {
-          setBackendApi(backendApiResult);
-        }
-      })();
-
-      return () => { disposed = true; };
-    },
-    [backendApiPromise],
-  );
-
-  return backendApi;
 }


### PR DESCRIPTION
Move `useBackendApi` out of `ITwinJsApp` bundle into the startup bundle to make the initial app load faster.