### PR TITLE
Make end-to-end tests more reliable

### DIFF
--- a/app/e2e-tests/src/demo-imodel.test.ts
+++ b/app/e2e-tests/src/demo-imodel.test.ts
@@ -8,7 +8,7 @@ import { getWidget, openDemoIModel } from "./utils";
 describe("demo iModel #web", () => {
   it("opens", async () => {
     await openDemoIModel(page);
-    const treeWidget = await getWidget(page, "Tree");
-    await treeWidget.waitForSelector(".core-tree-node");
+    const treeWidget = getWidget(page, "Tree");
+    await treeWidget.locator(".core-tree-node").first().waitFor();
   });
 });

--- a/app/e2e-tests/src/share.test.ts
+++ b/app/e2e-tests/src/share.test.ts
@@ -19,8 +19,8 @@ describe("share button #local #web", () => {
 
   before(async () => {
     await testConfiguration.openIModel(page);
-    const editor = await getEditor(page);
-    await (await editor.$("text={"))?.click();
+    const editor = getEditor(page);
+    await editor.locator("text={").first().click();
     await editor.press("Control+a");
     await editor.type("test ruleset text");
     await page.click('button:has-text("Share")');
@@ -49,11 +49,11 @@ describe("opening shared link #local #web", () => {
     // When only hash part of the URL changes, the reload will not happen, so we trigger it manually
     await page.reload();
 
-    const editor = await getEditor(page);
-    expect(await editor.$("text=test_ruleset")).not.to.be.null;
+    const editor = getEditor(page);
+    await editor.locator("text=test_ruleset").waitFor();
 
-    const treeWidget = await getWidget(page, "Tree");
-    expect(await treeWidget.waitForSelector("text=test_node")).not.to.be.null;
+    const treeWidget = getWidget(page, "Tree");
+    await treeWidget.locator("text=test_node").waitFor();
   });
 
   it("populates editor with ruleset when shared ruleset is invalid", async () => {
@@ -61,8 +61,8 @@ describe("opening shared link #local #web", () => {
     // When only hash part of the URL changes, the reload will not happen, so we trigger it manually
     await page.reload();
 
-    const editor = await getEditor(page);
-    const editorContent = await (await editor.$(".lines-content"))?.textContent();
+    const editor = getEditor(page);
+    const editorContent = await editor.locator(".lines-content").textContent();
     expect(editorContent).to.be.equal("invalid_test_ruleset");
   });
 
@@ -71,8 +71,8 @@ describe("opening shared link #local #web", () => {
     // When only hash part of the URL changes, the reload will not happen, so we trigger it manually
     await page.reload();
 
-    const editor = await getEditor(page);
-    const editorContent = await (await editor.$(".lines-content"))?.textContent();
+    const editor = getEditor(page);
+    const editorContent = await editor.locator(".lines-content").textContent();
     // A non-breaking space is separating these words
     expect(editorContent).to.be.equal("<invalid\xa0ruleset>");
   });

--- a/app/e2e-tests/src/tab-content/editor.test.ts
+++ b/app/e2e-tests/src/tab-content/editor.test.ts
@@ -12,22 +12,20 @@ describe("editor #local", () => {
   });
 
   it("is populated with template ruleset", async () => {
-    const editor = await getEditor(page);
+    const editor = getEditor(page);
     expect(await editor.textContent()).to.contain('"Ruleset1"');
   });
 
   it("suggests completions based on ruleset schema", async () => {
-    const editor = await getEditor(page);
-
-    await (await editor.$("text=true"))!.dblclick();
+    const editor = getEditor(page);
+    await editor.locator("text=true").first().dblclick();
     await editor.press("Backspace");
     await editor.press("Control+Space");
-    const suggestions = await editor.waitForSelector(".suggest-widget");
-
-    const options = await suggestions.$$("[role=option]");
-    expect(options.length).to.be.equal(2);
-    expect(await options[0].$("text=false")).not.to.be.null;
-    expect(await options[1].$("text=true")).not.to.be.null;
+    const options = editor.locator(".suggest-widget");
+    await options.waitFor();
+    expect(await options.locator("[role=option]").count()).to.be.equal(2);
+    expect(await options.locator("[role=option]", { hasText: "false" }).elementHandle()).not.to.be.null;
+    expect(await options.locator("[role=option]", { hasText: "true" }).elementHandle()).not.to.be.null;
   });
 
   describe("ruleset submission", () => {
@@ -36,38 +34,38 @@ describe("editor #local", () => {
     });
 
     it("submits ruleset when button is clicked", async () => {
-      const editor = await getEditor(page);
-
-      await (await editor.$("text=Element"))!.dblclick();
+      const editor = getEditor(page);
+      await editor.locator("text=Element").dblclick();
       await editor.press("Backspace");
 
-      await (await editor.$("text=Submit ruleset"))!.click();
-      const treeWidget = await getWidget(page, "Tree");
-      await treeWidget.waitForSelector("text=The data required for this tree layout is not available in this iModel.");
+      await editor.locator("text=Submit ruleset").click();
+      await getWidget(page, "Tree")
+        .locator("text=The data required for this tree layout is not available in this iModel.")
+        .waitFor();
     });
 
     it("submits ruleset when keyboard shortcut is pressed", async () => {
-      const editor = await getEditor(page);
-
-      await (await editor.$("text=Element"))!.dblclick();
+      const editor = getEditor(page);
+      await editor.locator("text=Element").dblclick();
       await editor.press("Backspace");
 
       await editor.press("Alt+Enter");
-      const treeWidget = await getWidget(page, "Tree");
-      await treeWidget.waitForSelector("text=The data required for this tree layout is not available in this iModel.");
+      await getWidget(page, "Tree")
+        .locator("text=The data required for this tree layout is not available in this iModel.")
+        .waitFor();
     });
 
     it("submits ruleset when command is invoked from the command palette", async () => {
-      const editor = await getEditor(page);
-
-      await (await editor.$("text=Element"))!.dblclick();
+      const editor = getEditor(page);
+      await editor.locator("text=Element").dblclick();
       await editor.press("Backspace");
 
       await editor.press("F1");
       await editor.type("Submit ruleset");
       await editor.press("Enter");
-      const treeWidget = await getWidget(page, "Tree");
-      await treeWidget.waitForSelector("text=The data required for this tree layout is not available in this iModel.");
+      await getWidget(page, "Tree")
+        .locator("text=The data required for this tree layout is not available in this iModel.")
+        .waitFor();
     });
   });
 });

--- a/app/e2e-tests/src/utils.ts
+++ b/app/e2e-tests/src/utils.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ElementHandle, Page } from "playwright";
+import { Locator, Page } from "playwright";
 
 export function getServiceUrl(): string {
   return process.env.SERVICE_URL ?? "http://localhost:8080";
@@ -30,13 +30,10 @@ export async function openDemoIModel(page: Page): Promise<void> {
   await page.waitForSelector("id=app-loader", { state: "detached" });
 }
 
-export async function getWidget(page: Page, widget: string): Promise<ElementHandle<SVGElement | HTMLElement>> {
-  return page.waitForSelector(`.nz-widget-widget:has([role=tab][title=${widget}]) .nz-widget-content`);
+export function getWidget(page: Page, widget: string): Locator {
+  return page.locator(`.nz-widget-widget:has([role=tab][title=${widget}]) .nz-widget-content`);
 }
 
-export async function getEditor(page: Page): Promise<ElementHandle<SVGElement | HTMLElement>> {
-  const element = await page.waitForSelector("[role=code]");
-  // Wait for syntax highlighting to kick in so that text nodes do not disappear while we interact with them
-  await Promise.race([element.waitForSelector(".mtk20"), element.waitForSelector(".mtk1")]);
-  return element;
+export function getEditor(page: Page): Locator {
+  return page.locator("[role=code]");
 }

--- a/app/e2e-tests/src/widgets/properties.test.ts
+++ b/app/e2e-tests/src/widgets/properties.test.ts
@@ -12,17 +12,17 @@ describe("properties widget #local", () => {
   });
 
   it("displays properties", async () => {
-    const propertiesWidget = await getWidget(page, "Properties");
-    await propertiesWidget.waitForSelector("text=Select element(s) to view properties.");
+    const propertiesWidget = getWidget(page, "Properties");
+    await propertiesWidget.locator("text=Select element(s) to view properties.").waitFor();
 
     await selectAnyTreeNode(page);
-    await propertiesWidget.waitForSelector("text=Selected Item(s)");
+    await propertiesWidget.locator("text=Selected Item(s)").waitFor();
   });
 
   it("updates properties when ruleset changes", async () => {
     await selectAnyTreeNode(page);
 
-    const editor = await getEditor(page);
+    const editor = getEditor(page);
     await page.click('text=""SelectedNodeInstances""');
     await editor.press("End");
     await editor.type(`,
@@ -30,14 +30,13 @@ describe("properties widget #local", () => {
 "propertyCategories": [{ "id": "custom", "label": "custom_category" }]`);
     await editor.press("Alt+Enter");
 
-    const propertiesWidget = await getWidget(page, "Properties");
-    await propertiesWidget.waitForSelector("text=custom_category");
+    const propertiesWidget = getWidget(page, "Properties");
+    await propertiesWidget.locator("text=custom_category").waitFor();
   });
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
   async function selectAnyTreeNode(page: Page): Promise<void> {
-    const treeWidget = await getWidget(page, "Tree");
-    await treeWidget.waitForSelector(".core-tree-node");
-    await (await treeWidget.$(".core-tree-node"))!.click();
+    const treeWidget = getWidget(page, "Tree");
+    await treeWidget.locator(".core-tree-node").first().click();
   }
 });

--- a/app/e2e-tests/src/widgets/tree.test.ts
+++ b/app/e2e-tests/src/widgets/tree.test.ts
@@ -11,18 +11,18 @@ describe("tree widget #local", () => {
   });
 
   it("displays tree hierarchy", async () => {
-    const treeWidget = await getWidget(page, "Tree");
-    await treeWidget.waitForSelector(".core-tree-node");
+    const treeWidget = getWidget(page, "Tree");
+    await treeWidget.locator(".core-tree-node").first().waitFor();
   });
 
   it("updates tree when ruleset changes", async () => {
-    const editor = await getEditor(page);
+    const editor = getEditor(page);
     await page.click('text=""rules""');
     await editor.press("Control+Enter");
     await editor.type('{ "ruleType": "CheckBox" },');
     await editor.press("Alt+Enter");
 
-    const treeWidget = await getWidget(page, "Tree");
-    await treeWidget.waitForSelector("input[type=checkbox]", { state: "attached" });
+    const treeWidget = getWidget(page, "Tree");
+    await treeWidget.locator("input[type=checkbox]").first().waitFor({ state: "attached" });
   });
 });


### PR DESCRIPTION
This PR makes most end-to-end test code use [Playwright's Locators API](https://playwright.dev/docs/api/class-locator), which is the recommended way to interact with rendered DOM.

We previously worked with element handles directly, but handles are invalidated upon element removal from the DOM tree, requiring us to re-check element's existence before each use. Failure to do so has lead some of our CI runs to fail spontaneously.

By switching to using locators, we should see fewer test failures and be able to write simpler test code.