### PR TITLE
Fix excessive requests for iModel thumbnails

### DIFF
--- a/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
@@ -16,6 +16,10 @@ import { iModelBrowserContext, IModelTile } from "./IModelBrowser";
 export function DemoIModelBrowser(): React.ReactElement {
   const { demoAuthorizationClient } = useAuthorization();
   const { demoIModelData, loadIModelData } = useDemoIModelData(demoAuthorizationClient);
+  const handleVisible = useEvent(
+    (iModelId: string) => demoIModelData.get(iModelId) === undefined && loadIModelData(iModelId),
+  );
+
   let { searchQuery } = React.useContext(iModelBrowserContext);
   searchQuery = searchQuery.trim().toLowerCase();
   const iModels = [...demoIModels.entries()]
@@ -40,7 +44,7 @@ export function DemoIModelBrowser(): React.ReactElement {
             name={name}
             description={demoIModelData.get(iModelId)?.description}
             authorizationClient={demoAuthorizationClient}
-            onVisible={() => demoIModelData.get(iModelId) === undefined && loadIModelData(iModelId)}
+            onVisible={handleVisible}
           />
         ))
       }
@@ -80,4 +84,11 @@ function useDemoIModelData(authorizationClient: AuthorizationClient): {
     demoIModelData,
     loadIModelData: ref.current.loadIModelData,
   };
+}
+
+// Loosely based on useEvent proposal https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md
+function useEvent<T extends unknown[], U>(handleEvent: (...args: T) => U): (...args: T) => U {
+  const handleEventRef = React.useRef(handleEvent);
+  handleEventRef.current = handleEvent;
+  return React.useCallback((...args) => handleEventRef.current(...args), []);
 }

--- a/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/DemoIModelBrowser.tsx
@@ -9,7 +9,7 @@ import { FluidGrid } from "@itwin/itwinui-layouts-react";
 import { Title } from "@itwin/itwinui-react";
 import { useAuthorization } from "../Authorization";
 import { VerticalStack } from "../common/CenteredStack";
-import { getIModel } from "../ITwinApi";
+import { callITwinApi, getIModel } from "../ITwinApi";
 import { demoIModels } from "../ITwinJsApp/IModelIdentifier";
 import { iModelBrowserContext, IModelTile } from "./IModelBrowser";
 
@@ -61,7 +61,7 @@ function useDemoIModelData(authorizationClient: AuthorizationClient): {
   const ref = React.useRef({
     disposed: false,
     loadIModelData: async (iModelId: string) => {
-      const response = await getIModel(iModelId, authorizationClient);
+      const response = await callITwinApi(getIModel(iModelId), authorizationClient);
       if (ref.current.disposed || !response) {
         return;
       }

--- a/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
@@ -225,7 +225,7 @@ export interface IModelTileProps {
   name: React.ReactNode;
   description: string | undefined;
   authorizationClient: AuthorizationClient | undefined;
-  onVisible?: (() => void) | undefined;
+  onVisible?: ((iModelId: string) => void) | undefined;
 }
 
 export function IModelTile(props: IModelTileProps): React.ReactElement {
@@ -246,7 +246,7 @@ export function IModelTile(props: IModelTileProps): React.ReactElement {
 
       const handleObservation = async (isIntersecting: boolean) => {
         if (isIntersecting) {
-          onVisible?.();
+          onVisible?.(props.iModelId);
           if (thumbnail !== undefined) {
             return;
           }

--- a/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
@@ -16,7 +16,7 @@ import { appNavigationContext } from "../AppContext";
 import { useAuthorization } from "../Authorization";
 import { VerticalStack } from "../common/CenteredStack";
 import { useLocalStorage } from "../common/LocalStorage";
-import { getIModel, getIModelThumbnail } from "../ITwinApi";
+import { callITwinApi, getIModel, getIModelThumbnail } from "../ITwinApi";
 import { BackendApi } from "../ITwinJsApp/api/BackendApi";
 import {
   demoIModels, IModelIdentifier, isDemoIModel, isIModelIdentifier, isSnapshotIModel, ITwinIModelIdentifier,
@@ -251,7 +251,7 @@ export function IModelTile(props: IModelTileProps): React.ReactElement {
             return;
           }
 
-          const response = await getIModelThumbnail(props.iModelId, authorizationClient);
+          const response = await callITwinApi(getIModelThumbnail(props.iModelId), authorizationClient);
           if (!disposed && response) {
             setThumbnail(URL.createObjectURL(response));
           }
@@ -335,7 +335,7 @@ function RecentIModelTile(props: RecentIModelTileProps): React.ReactElement {
 
       let disposed = false;
       void (async () => {
-        const response = await getIModel(props.iModelIdentifier.iModelId, authClient);
+        const response = await callITwinApi(getIModel(props.iModelIdentifier.iModelId), authClient);
         if (!disposed && response) {
           setIModel({ name: response.displayName, description: response.description ?? "" });
         }

--- a/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
@@ -14,7 +14,9 @@ import { appNavigationContext } from "../AppContext";
 import { AuthorizationState, useAuthorization } from "../Authorization";
 import { HorizontalStack, VerticalStack } from "../common/CenteredStack";
 import { OfflineModeExplainer } from "../common/OfflineModeExplainer";
-import { getProjectIModels, getUserProjects, IModelRepresentation, ProjectRepresentation } from "../ITwinApi";
+import {
+  callITwinApi, getProjectIModels, getUserProjects, IModelRepresentation, ProjectRepresentation,
+} from "../ITwinApi";
 import { LoadingHint } from "../ITwinJsApp/common/LoadingHint";
 import { iModelBrowserContext, IModelTile } from "./IModelBrowser";
 
@@ -31,7 +33,7 @@ export function ITwinBrowser(): React.ReactElement {
         return;
       }
 
-      const response = await getUserProjects("representation", userAuthorizationClient, searchQuery);
+      const response = await callITwinApi(getUserProjects("representation", searchQuery), userAuthorizationClient);
       if (!disposedRef.current && response) {
         setITwins(response.sort((a, b) => Date.parse(b.registrationDateTime) - Date.parse(a.registrationDateTime)));
       }
@@ -151,7 +153,10 @@ export function ITwinIModelBrowser(): React.ReactElement {
         return;
       }
 
-      const response = await getProjectIModels(iTwin, "representation", userAuthorizationClient, searchQuery);
+      const response = await callITwinApi(
+        getProjectIModels(iTwin, "representation", searchQuery),
+        userAuthorizationClient,
+      );
       if (!disposedRef.current && response) {
         setIModels(response.sort((a, b) => Date.parse(b.createdDateTime) - Date.parse(a.createdDateTime)));
       }

--- a/app/frontend/src/app/OpenIModel.tsx
+++ b/app/frontend/src/app/OpenIModel.tsx
@@ -15,7 +15,7 @@ import { LandingPage } from "./common/LandingPage";
 import { LoadingIndicator } from "./common/LoadingIndicator";
 import { PageNotFound } from "./errors/PageNotFound";
 import { IModelBrowserTab } from "./IModelBrowser/IModelBrowser";
-import { getIModel, getProject } from "./ITwinApi";
+import { callITwinApi, getIModel, getProject } from "./ITwinApi";
 import { BackendApi } from "./ITwinJsApp/api/BackendApi";
 import {
   demoIModels, IModelIdentifier, isDemoIModel, isSnapshotIModel, ITwinIModelIdentifier, SnapshotIModelIdentifier,
@@ -196,8 +196,8 @@ function usePopulateHeaderBreadcrumbs(
       } else if (authorizationClient) {
         void (async () => {
           const [project, iModel] = await Promise.all([
-            getProject(iModelIdentifier.iTwinId, authorizationClient),
-            getIModel(iModelIdentifier.iModelId, authorizationClient),
+            callITwinApi(getProject(iModelIdentifier.iTwinId), authorizationClient),
+            callITwinApi(getIModel(iModelIdentifier.iModelId), authorizationClient),
           ]);
           if (!disposed && project && iModel) {
             setBreadcrumbs([


### PR DESCRIPTION
We now cache responses from iTwin API where the returned resource is assumed to never change (currently only applies to iModel thumbnails).

We also deduplicate active requests for the same resource in two second windows.

The component that highlighted the lack of caching has been optimised to render fewer times.