### PR TITLE
Specify name for the package in repository root

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "workspace",
   "version": "0.0.1",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Mend scan has started failing with an error:

```
2022-09-22T13:34:03.7136466Z ------------------------------------------------------------------------
2022-09-22T13:34:03.7180374Z -------------------- Start: Update Inventory ---------------------------
2022-09-22T13:34:03.7181569Z ------------------------------------------------------------------------
2022-09-22T13:34:04.6443614Z [ERROR] [2022-09-22 13:34:04,598 +0000] - Failed to send request to WhiteSource server: Illegal arguments: Invalid NPM dependency info, DependencyInfo@6869c3cd[groupId= ,artifactId= -0.0.1.tgz,version= 0.0.1,filename= -0.0.1.tgz,dependencyType= NPM ]
2022-09-22T13:34:04.6453441Z [INFO] [2022-09-22 13:34:04,598 +0000] - Support token: 1122f7f4fd0924d7fb7257a6b1e2e019b1663853644298
2022-09-22T13:34:04.6462059Z [INFO] [2022-09-22 13:34:04,598 +0000] - Process finished with exit code SERVER_FAILURE (Failed to send request to WhiteSource server: Illegal arguments: Invalid NPM dependency info, DependencyInfo@6869c3cd[groupId= ,artifactId= -0.0.1.tgz,version= 0.0.1,filename= -0.0.1.tgz,dependencyType= NPM ]
2022-09-22T13:34:04.6468307Z Support token: 1122f7f4fd0924d7fb7257a6b1e2e019b1663853644298)
2022-09-22T13:34:04.6472792Z [INFO] [2022-09-22 13:34:04,598 +0000] - Log files are found at: .\whitesource\Thu-Sep-22-2022-13.33.14
2022-09-22T13:34:04.6477500Z [INFO] [2022-09-22 13:34:04,614 +0000] - 
```

I suspect this is caused by the root `package.json` not having a name field.