### PR TITLE
Increase default Playwright locator timeout in accordance with mocha timeout

### DIFF
--- a/app/e2e-tests/src/setup.ts
+++ b/app/e2e-tests/src/setup.ts
@@ -82,6 +82,7 @@ async function execute(command: string): Promise<void> {
 async function setupBrowser({ debug }: { debug: boolean }): Promise<void> {
   browser = await chromium.launch({ headless: !debug, slowMo: debug ? 100 : undefined });
   page = await browser.newPage();
+  page.setDefaultTimeout(60_000);
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"], { origin: getServiceUrl() });
 }
 


### PR DESCRIPTION
This change should have been made in #109.