### PR TITLE
Store app metadata in index.html

### DIFF
--- a/app/frontend/custom.d.ts
+++ b/app/frontend/custom.d.ts
@@ -6,9 +6,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      readonly APPLICATION_INSIGHTS_CONNECTION_STRING_DEV: string | undefined;
-      readonly APPLICATION_INSIGHTS_CONNECTION_STRING_QA: string | undefined;
-      readonly APPLICATION_INSIGHTS_CONNECTION_STRING_PROD: string | undefined;
+      readonly APPLICATION_INSIGHTS_CONNECTION_STRING: string | undefined;
       readonly DEPLOYMENT_TYPE: "dev" | "web" | "local";
       readonly IMJS_URL_PREFIX: string | undefined;
       readonly OAUTH_CLIENT_ID: string | undefined;

--- a/app/frontend/src/app/App.tsx
+++ b/app/frontend/src/app/App.tsx
@@ -22,7 +22,7 @@ import { ITwinBrowser, ITwinIModelBrowser } from "./IModelBrowser/ITwinIModelBro
 import { LocalIModelBrowser } from "./IModelBrowser/LocalIModelBrowser";
 import { isSnapshotIModel } from "./ITwinJsApp/IModelIdentifier";
 import { ITwinJsAppData, OpenIModel } from "./OpenIModel";
-import { applyUrlPrefix } from "./utils/Environment";
+import { appInsightsConnectionString, applyUrlPrefix, clientId } from "./utils/Environment";
 
 export function App(): React.ReactElement {
   const appContextValue = useAppNavigationContext();
@@ -48,10 +48,10 @@ export function App(): React.ReactElement {
   );
 }
 
-const AuthorizationProvider = process.env.OAUTH_CLIENT_ID
+const AuthorizationProvider = clientId
   ? createAuthorizationProvider({
     authority: applyUrlPrefix("https://ims.bentley.com"),
-    client_id: process.env.OAUTH_CLIENT_ID,
+    client_id: clientId,
     redirect_uri: "/auth/callback",
     silent_redirect_uri: "/auth/silent",
     post_logout_redirect_uri: "/",
@@ -137,12 +137,11 @@ function useBackgroundITwinJsAppLoading(): ITwinJsAppData | undefined {
 function useApplicationInsights(): void {
   React.useEffect(
     () => {
-      const connectionString = getConnectionString();
-      if (connectionString) {
+      if (appInsightsConnectionString) {
         void (async () => {
           try {
             const { initialize } = await import("./ApplicationInsights");
-            initialize(connectionString);
+            initialize(appInsightsConnectionString);
           } catch (error) {
             // eslint-disable-next-line no-console
             console.warn("ApplicationInsights initialization failed", error);
@@ -152,19 +151,6 @@ function useApplicationInsights(): void {
     },
     [],
   );
-
-  function getConnectionString(): string | undefined {
-    const hostname = window.location.hostname;
-    if (hostname.startsWith("dev-")) {
-      return process.env.APPLICATION_INSIGHTS_CONNECTION_STRING_DEV;
-    }
-
-    if (hostname.startsWith("qa-")) {
-      return process.env.APPLICATION_INSIGHTS_CONNECTION_STRING_QA;
-    }
-
-    return process.env.APPLICATION_INSIGHTS_CONNECTION_STRING_PROD;
-  }
 }
 
 interface AppSideNavigationProps {

--- a/app/frontend/src/app/utils/Environment.ts
+++ b/app/frontend/src/app/utils/Environment.ts
@@ -3,13 +3,21 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-/** Adds process.env.IMJS_URL_PREFIX to URL hostname. */
+/** Adds urlPrefix to URL hostname. */
 export function applyUrlPrefix(url: string): string {
-  if (!process.env.IMJS_URL_PREFIX) {
+  if (!urlPrefix) {
     return url;
   }
 
   const modifierUrl = new URL(url);
-  modifierUrl.hostname = process.env.IMJS_URL_PREFIX + modifierUrl.hostname;
+  modifierUrl.hostname = urlPrefix + modifierUrl.hostname;
   return modifierUrl.toString();
+}
+
+export const clientId = getAppMetadata("clientId");
+export const urlPrefix = getAppMetadata("urlPrefix");
+export const appInsightsConnectionString = getAppMetadata("appInsights");
+
+function getAppMetadata(propertyName: string): string {
+  return document.head.querySelector(`meta[itemprop=${propertyName}]`)?.getAttribute("content") ?? "";
 }


### PR DESCRIPTION
Having this app metadata available in a central location allows us to use variable substitution at deployment time to deploy the app with different configurations in dev, qa, and prod environments.

Related to issue #89.