### PR TITLE
Fix opening demo iModels in QA environment

### DIFF
--- a/app/frontend/src/app/ITwinJsApp/ITwinJsAppContext.ts
+++ b/app/frontend/src/app/ITwinJsApp/ITwinJsAppContext.ts
@@ -5,7 +5,7 @@
 import * as React from "react";
 import { BackendApi } from "./api/BackendApi";
 
-export const backendApiContext = React.createContext<BackendApi>(new BackendApi());
+export const backendApiContext = React.createContext<BackendApi>(new BackendApi({} as any));
 
 export interface RulesetEditorContext {
   activeTab: RulesetEditorTab;

--- a/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
@@ -114,9 +114,10 @@ function useIModel(
       setIModel(undefined);
 
       IModelApp.authorizationClient = authorizationClient;
-      const backendUrl = "https://api.bentley.com/imodeljs";
-      backendApi.protocol.pathPrefix = (process.env.DEPLOYMENT_TYPE === "web"
-        && isDemoIModel(iModelIdentifier)) ? backendUrl : applyUrlPrefix(backendUrl);
+      if (process.env.DEPLOYMENT_TYPE === "web") {
+        const backendUrl = "https://api.bentley.com/imodeljs";
+        backendApi.protocol.pathPrefix = isDemoIModel(iModelIdentifier) ? backendUrl : applyUrlPrefix(backendUrl);
+      }
 
       let disposed = false;
       const iModelPromise = backendApi.openIModel(iModelIdentifier);

--- a/app/frontend/src/app/ITwinJsApp/api/BackendApi.ts
+++ b/app/frontend/src/app/ITwinJsApp/api/BackendApi.ts
@@ -4,11 +4,13 @@
 *--------------------------------------------------------------------------------------------*/
 import { IModelMetadata, PresentationRulesEditorRpcInterface } from "@app/common";
 import { Guid, Id64, Id64String, Logger } from "@itwin/core-bentley";
-import { IModelVersion } from "@itwin/core-common";
+import { BentleyCloudRpcProtocol, IModelVersion } from "@itwin/core-common";
 import { CheckpointConnection, IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
 import { IModelIdentifier, isDemoIModel, isSnapshotIModel } from "../IModelIdentifier";
 
 export class BackendApi {
+  constructor(public protocol: BentleyCloudRpcProtocol) { }
+
   public async getAvailableIModels(): Promise<IModelMetadata[]> {
     return PresentationRulesEditorRpcInterface.getClient().getAvailableIModels();
   }


### PR DESCRIPTION
Demo iModels require production version of general purpose backend.

This change adds logic that detects when a demo iModel is being opened and updates global iTwin.js configuration to point to production environment.

Known issues:

* Demo iModel thumbnails and descriptions are not loading when app is deployed on non-production environment.
