### PR TITLE
Warn users with unsupported versions of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "engines": {
     "pnpm": ">=6",
-    "npm": "<0"
+    "npm": "<0",
+    "node": ">=16"
   },
   "dependencies": {
     "cross-env": "^7.0.3",


### PR DESCRIPTION
The warning will appear during `pnpm install`.