### PR TITLE
Supply unified selection context to app components

### DIFF
--- a/app/frontend/src/app/ITwinJsApp/content-tabs/ViewportTab.tsx
+++ b/app/frontend/src/app/ITwinJsApp/content-tabs/ViewportTab.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { Id64String } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import { ViewportComponent } from "@itwin/imodel-components-react";
-import { viewWithUnifiedSelection } from "@itwin/presentation-components";
+import { UnifiedSelectionContextProvider, viewWithUnifiedSelection } from "@itwin/presentation-components";
 import { backendApiContext } from "../ITwinJsAppContext";
 
 export interface ViewportTabProps {
@@ -29,7 +29,11 @@ function ViewportForIModel(props: ViewportForIModelProps): React.ReactElement | 
     return null;
   }
 
-  return <ViewportWithUnifiedSelection imodel={props.imodel} viewDefinitionId={viewDefinitionId} />;
+  return (
+    <UnifiedSelectionContextProvider imodel={props.imodel} selectionLevel={0}>
+      <ViewportWithUnifiedSelection imodel={props.imodel} viewDefinitionId={viewDefinitionId} />
+    </UnifiedSelectionContextProvider>
+  );
 }
 
 function useViewDefinitionId(imodel: IModelConnection): Id64String | undefined {

--- a/app/frontend/src/app/ITwinJsApp/widgets/PropertyGridWidget.tsx
+++ b/app/frontend/src/app/ITwinJsApp/widgets/PropertyGridWidget.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
 import { SvgCollapseAll, SvgExpandAll } from "@itwin/itwinui-icons-react";
 import { Button, IconButton } from "@itwin/itwinui-react";
+import { UnifiedSelectionContextProvider } from "@itwin/presentation-components";
 import { EditableRuleset, PropertyGrid, PropertyGridAttributes } from "@itwin/presentation-rules-editor-react";
 import { VerticalStack } from "../../common/CenteredStack";
 import { LoadingIndicator } from "../../common/LoadingIndicator";
@@ -29,7 +30,11 @@ export function PropertyGridWidget(props: PropertyGridProps): React.ReactElement
     return <LoadingHint />;
   }
 
-  return <LoadedPropertyGrid iModel={props.imodel} ruleset={props.ruleset} />;
+  return (
+    <UnifiedSelectionContextProvider imodel={props.imodel} selectionLevel={0}>
+      <LoadedPropertyGrid iModel={props.imodel} ruleset={props.ruleset} />
+    </UnifiedSelectionContextProvider>
+  );
 }
 
 interface LoadedPropertyGridProps {

--- a/app/frontend/src/app/ITwinJsApp/widgets/TreeWidget.tsx
+++ b/app/frontend/src/app/ITwinJsApp/widgets/TreeWidget.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { IModelConnection } from "@itwin/core-frontend";
+import { UnifiedSelectionContextProvider } from "@itwin/presentation-components";
 import { EditableRuleset, Tree } from "@itwin/presentation-rules-editor-react";
 import { AutoSizer } from "../common/AutoSizer";
 import { LoadingHint } from "../common/LoadingHint";
@@ -26,8 +27,10 @@ export function TreeWidget(props: TreeWidgetProps): React.ReactElement {
   }
 
   return (
-    <AutoSizer>
-      {({ width, height }) => <Tree width={width} height={height} iModel={imodel} editableRuleset={ruleset} />}
-    </AutoSizer>
+    <UnifiedSelectionContextProvider imodel={imodel} selectionLevel={0}>
+      <AutoSizer>
+        {({ width, height }) => <Tree width={width} height={height} iModel={imodel} editableRuleset={ruleset} />}
+      </AutoSizer>
+    </UnifiedSelectionContextProvider>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/iTwin/presentation-rules-editor/issues/87

The context is required for some custom property value renderers like [SelectableInstance](https://www.itwinjs.org/presentation/content/propertyvaluerenderers/#selectableinstance) one.