### PR TITLE
Experimental: Station values renderer

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -21,6 +21,8 @@
     "@itwin/core-geometry": "3.6.0",
     "@itwin/core-quantity": "3.6.0",
     "@itwin/ecschema-metadata": "3.6.0",
+    "@itwin/ecschema-rpcinterface-common": "3.6.0",
+    "@itwin/ecschema-rpcinterface-impl": "3.6.0",
     "@itwin/eslint-plugin": "3.6.0",
     "@itwin/express-server": "3.6.0",
     "@itwin/imodels-access-backend": "^1.0.1",

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -7,6 +7,7 @@ import { rpcInterfaces } from "@app/common";
 import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
 import { Logger, LogLevel } from "@itwin/core-bentley";
 import { RpcConfiguration } from "@itwin/core-common";
+import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { Presentation, PresentationBackendLoggerCategory, PresentationBackendNativeLoggerCategory } from "@itwin/presentation-backend";
 import { PresentationRulesEditorRpcImpl } from "./PresentationRulesEditorRpcImpl";
@@ -33,6 +34,7 @@ void (async () => {
   });
 
   RpcConfiguration.developmentMode = true;
+  ECSchemaRpcImpl.register();
   PresentationRulesEditorRpcImpl.register();
 
   await initialize(rpcInterfaces);

--- a/app/common/package.json
+++ b/app/common/package.json
@@ -15,6 +15,8 @@
     "@itwin/core-common": "3.6.0",
     "@itwin/core-geometry": "3.6.0",
     "@itwin/core-quantity": "3.6.0",
+    "@itwin/ecschema-metadata": "3.6.0",
+    "@itwin/ecschema-rpcinterface-common": "3.6.0",
     "@itwin/eslint-plugin": "3.6.0",
     "@itwin/presentation-common": "3.6.0",
     "eslint": "^7.30.0",

--- a/app/common/src/Rpcs.ts
+++ b/app/common/src/Rpcs.ts
@@ -3,10 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { IModelReadRpcInterface, IModelTileRpcInterface, SnapshotIModelRpcInterface } from "@itwin/core-common";
+import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { PresentationRulesEditorRpcInterface } from "./PresentationRulesEditorRpcInterface";
 
 export const rpcInterfaces = [
+  ECSchemaRpcInterface,
   IModelTileRpcInterface,
   IModelReadRpcInterface,
   SnapshotIModelRpcInterface,

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -29,6 +29,8 @@
     "@itwin/core-orbitgt": "3.6.0",
     "@itwin/core-quantity": "3.6.0",
     "@itwin/core-react": "3.6.0",
+    "@itwin/ecschema-metadata": "3.6.0",
+    "@itwin/ecschema-rpcinterface-common": "3.6.0",
     "@itwin/eslint-plugin": "3.6.0",
     "@itwin/imodel-browser-react": "^0.12.1",
     "@itwin/imodel-components-react": "3.6.0",

--- a/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
@@ -4,23 +4,23 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { rpcInterfaces } from "@app/common";
-import {
-  AppNotificationManager, ConfigurableUiManager, FrameworkReducer, StateManager, UiFramework,
-} from "@itwin/appui-react";
+import { AppNotificationManager, ConfigurableUiManager, FrameworkReducer, StateManager, UiFramework } from "@itwin/appui-react";
 import { Logger, LogLevel } from "@itwin/core-bentley";
-import {
-  AuthorizationClient, BentleyCloudRpcManager, ChangesetIndexAndId, IModelVersion, RpcConfiguration,
-} from "@itwin/core-common";
+import { AuthorizationClient, BentleyCloudRpcManager, ChangesetIndexAndId, IModelVersion, RpcConfiguration } from "@itwin/core-common";
 import { FrontendHubAccess, IModelApp, IModelIdArg } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { FrontendIModelsAccess } from "@itwin/imodels-access-frontend";
 import { IModelsClient } from "@itwin/imodels-client-management";
 import { Presentation } from "@itwin/presentation-frontend";
 import { LoadingIndicator } from "../common/LoadingIndicator";
-import { applyUrlPrefix } from "../utils/Environment";
+import { applyUrlPrefix, EXPERIMENTAL_STATION_VALUE_RENDERER } from "../utils/Environment";
 import { BackendApi } from "./api/BackendApi";
 import { demoIModels, IModelIdentifier } from "./IModelIdentifier";
 import { InitializedApp } from "./InitializedApp";
+
+if (EXPERIMENTAL_STATION_VALUE_RENDERER) {
+  require("../experimental/StationPropertyValueRenderer");
+}
 
 export interface ITwinJsAppProps {
   backendApiPromise: Promise<BackendApi>;

--- a/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
+++ b/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
@@ -42,8 +42,8 @@ export class StationPropertyValueRenderer implements IPropertyValueRenderer {
     return record.property.renderer?.name === "Station";
   }
 
-  public render(record: PropertyRecord, context?: PropertyValueRendererContext) {
-    return <StationPropertyValueRendererImpl record={record} context={context} />;
+  public render(_record: PropertyRecord, context?: PropertyValueRendererContext) {
+    return <StationPropertyValueRendererImpl context={context} />;
   }
 }
 

--- a/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
+++ b/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
@@ -47,7 +47,7 @@ export class StationPropertyValueRenderer implements IPropertyValueRenderer {
   }
 }
 
-function StationPropertyValueRendererImpl(props: { record: PropertyRecord, context?: PropertyValueRendererContext }) {
+function StationPropertyValueRendererImpl(props: { context?: PropertyValueRendererContext }) {
   const { value: iModelSelectedElementIds, inProgress } = useIModelSelectedElementIds();
 
   if (inProgress)
@@ -126,6 +126,9 @@ function useComputedStationValue(props: { imodel: IModelConnection, elementId: I
   }, [schemaContext]));
 
   return useDebouncedAsyncValue(React.useCallback(async () => {
+    if (formatterSpec.inProgress)
+      return null;
+
     const ecsql = `
       SELECT
         linearlyLocated.DistanceAlongFromStart DistanceAlong,
@@ -170,10 +173,10 @@ function useComputedStationValue(props: { imodel: IModelConnection, elementId: I
     }
     if (!queryResult)
       return "<no value>";
-    if (formatterSpec.inProgress)
-      return null;
+
     if (!formatterSpec.value)
       return `Distance along: ${queryResult.distanceAlong}; \nStation value: ${queryResult.stationValue}`;
+
     return Formatter.formatQuantity(queryResult.stationValue, formatterSpec.value);
   }, [formatterSpec.inProgress, formatterSpec.value, props.imodel, props.elementId]));
 }

--- a/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
+++ b/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/* eslint-disable no-console */
+
+import * as React from "react";
+import { PropertyRecord } from "@itwin/appui-abstract";
+import { IPropertyValueRenderer, PropertyValueRendererContext, PropertyValueRendererManager, useDebouncedAsyncValue } from "@itwin/components-react";
+import { Id64String } from "@itwin/core-bentley";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+import { IModelConnection } from "@itwin/core-frontend";
+import { Format, Formatter, FormatterSpec } from "@itwin/core-quantity";
+import { ECVersion, SchemaContext, Format as SchemaFormat, SchemaKey, SchemaUnitProvider } from "@itwin/ecschema-metadata";
+import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
+import { KeySet } from "@itwin/presentation-common";
+import { useUnifiedSelectionContext } from "@itwin/presentation-components";
+import { Presentation } from "@itwin/presentation-frontend";
+
+Presentation.registerInitializationHandler(async (): Promise<() => void> => {
+  const customRenderers: Array<{ name: string, renderer: IPropertyValueRenderer }> = [
+    { name: "Station", renderer: new StationPropertyValueRenderer() },
+  ];
+
+  for (const { name, renderer } of customRenderers) {
+    PropertyValueRendererManager.defaultManager.registerRenderer(name, renderer);
+  }
+
+  return () => {
+    for (const { name } of customRenderers) {
+      PropertyValueRendererManager.defaultManager.unregisterRenderer(name);
+    }
+  };
+});
+
+/**
+ * Property value renderer for STATION values.
+ * @alpha
+ */
+export class StationPropertyValueRenderer implements IPropertyValueRenderer {
+  public canRender(record: PropertyRecord) {
+    return record.property.renderer?.name === "Station";
+  }
+
+  public render(record: PropertyRecord, context?: PropertyValueRendererContext) {
+    return <StationPropertyValueRendererImpl record={record} context={context} />;
+  }
+}
+
+function StationPropertyValueRendererImpl(props: { record: PropertyRecord, context?: PropertyValueRendererContext }) {
+  const { value: iModelSelectedElementIds, inProgress } = useIModelSelectedElementIds();
+
+  if (inProgress)
+    return null;
+
+  if (!iModelSelectedElementIds)
+    return <>Error: No selection context?</>;
+
+  if (iModelSelectedElementIds.elementIds.length === 0)
+    return <>No elements selected</>;
+
+  if (iModelSelectedElementIds.elementIds.length > 1)
+    return <>Error: Only 1 element supported</>;
+
+  return <ElementsStationPropertyValue imodel={iModelSelectedElementIds.imodel} elementId={iModelSelectedElementIds.elementIds[0]} context={props.context} />;
+}
+
+function ElementsStationPropertyValue(props: { imodel: IModelConnection, elementId: Id64String, context?: PropertyValueRendererContext }) {
+  const { value } = useComputedStationValue({ imodel: props.imodel, elementId: props.elementId });
+  return (
+    <span style={props.context?.style} title={value ?? ""}>{value}</span>
+  );
+}
+
+function useIModelSelectedElementIds() {
+  const selectionContext = useUnifiedSelectionContext();
+  return useDebouncedAsyncValue(React.useCallback(async () => {
+    if (!selectionContext)
+      return undefined;
+
+    const res = await Presentation.presentation.getContentInstanceKeys({
+      imodel: selectionContext.imodel,
+      keys: new KeySet(selectionContext.getSelection()),
+      rulesetOrId: {
+        id: "selected-elements",
+        rules: [{
+          ruleType: "Content",
+          specifications: [{
+            specType: "SelectedNodeInstances",
+            acceptableSchemaName: "BisCore",
+            acceptableClassNames: ["Element"],
+            acceptablePolymorphically: true,
+          }],
+        }],
+      },
+    });
+    const elementIds = new Array<Id64String>();
+    for await (const key of res.items()) {
+      elementIds.push(key.id);
+    }
+    return { imodel: selectionContext.imodel, elementIds };
+  }, [selectionContext]));
+}
+
+function useComputedStationValue(props: { imodel: IModelConnection, elementId: Id64String; }) {
+  const schemaContext = React.useMemo(() => {
+    const ctx = new SchemaContext();
+    ctx.addLocater(new ECSchemaRpcLocater(props.imodel.getRpcProps()));
+    return ctx;
+  }, [props.imodel]);
+
+  const formatterSpec = useDebouncedAsyncValue(React.useCallback(async () => {
+    const unitsProvider = new SchemaUnitProvider(schemaContext);
+    const persistenceUnit = await unitsProvider.findUnitByName("Units:M");
+    const formatsSchema = await schemaContext.getSchema(new SchemaKey("Formats", new ECVersion(1)));
+    if (!formatsSchema) {
+      console.error(`Failed to find "Formats" schema.`);
+      return undefined;
+    }
+    const schemaFormat = await formatsSchema.getItem<SchemaFormat>("StationZ_1000_3");
+    if (!schemaFormat) {
+      console.error(`Failed to find the "StationZ_1000_3" format in "Formats" schema.`);
+      return undefined;
+    }
+    return FormatterSpec.create("", await Format.createFromJSON("", unitsProvider, schemaFormat.toJSON()), unitsProvider, persistenceUnit);
+  }, [schemaContext]));
+
+  return useDebouncedAsyncValue(React.useCallback(async () => {
+    const ecsql = `
+      SELECT
+        linearlyLocated.DistanceAlongFromStart DistanceAlong,
+        (
+          COALESCE(station.Station, alg.StartStation) + (
+            linearlyLocated.DistanceAlongFromStart - COALESCE(
+              stationAt.AtPosition.DistanceAlongFromStart,
+              alg.StartValue,
+              0
+            )
+          )
+        ) StationValue
+      FROM
+        rralign.Alignment alg
+      JOIN (
+        SELECT
+          along.TargetECInstanceId LinearElementId,
+          fromTo.FromPosition.DistanceAlongFromStart DistanceAlongFromStart
+        FROM
+          lr.ILinearlyLocatedAlongILinearElement along
+          JOIN lr.LinearlyReferencedFromToLocation fromTo ON along.SourceECInstanceId = fromTo.Element.Id
+        WHERE
+          fromTo.Element.Id = ?
+      ) linearlyLocated ON alg.ECInstanceId = linearlyLocated.LinearElementId
+      LEFT JOIN rralign.AlignmentStation station ON alg.ECInstanceId = station.Parent.Id
+      LEFT JOIN lr.LinearlyReferencedAtLocation stationAt ON station.ECInstanceId = stationAt.Element.Id
+      WHERE
+        station.ECInstanceId IS NULL
+        OR stationAt.AtPosition.DistanceAlongFromStart <= linearlyLocated.DistanceAlongFromStart
+      ORDER BY
+        stationAt.AtPosition.DistanceAlongFromStart DESC
+      LIMIT
+        1
+    `;
+    let queryResult: { distanceAlong: number, stationValue: number } | undefined;
+    for await (const row of props.imodel.query(ecsql, (new QueryBinder()).bindId(1, props.elementId), { rowFormat: QueryRowFormat.UseECSqlPropertyIndexes })) {
+      queryResult = {
+        distanceAlong: row[0],
+        stationValue: row[1],
+      };
+      break;
+    }
+    if (!queryResult)
+      return "<no value>";
+    if (formatterSpec.inProgress)
+      return null;
+    if (!formatterSpec.value)
+      return `Distance along: ${queryResult.distanceAlong}; \nStation value: ${queryResult.stationValue}`;
+    return Formatter.formatQuantity(queryResult.stationValue, formatterSpec.value);
+  }, [formatterSpec.inProgress, formatterSpec.value, props.imodel, props.elementId]));
+}

--- a/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
+++ b/app/frontend/src/app/experimental/StationPropertyValueRenderer.tsx
@@ -102,7 +102,7 @@ function useIModelSelectedElementIds() {
   }, [selectionContext]));
 }
 
-function useComputedStationValue(props: { imodel: IModelConnection, elementId: Id64String; }) {
+function useComputedStationValue(props: { imodel: IModelConnection, elementId: Id64String }) {
   const schemaContext = React.useMemo(() => {
     const ctx = new SchemaContext();
     ctx.addLocater(new ECSchemaRpcLocater(props.imodel.getRpcProps()));

--- a/app/frontend/src/app/utils/Environment.ts
+++ b/app/frontend/src/app/utils/Environment.ts
@@ -21,3 +21,5 @@ export const appInsightsConnectionString = getAppMetadata("appInsights");
 function getAppMetadata(propertyName: string): string {
   return document.head.querySelector(`meta[itemprop=${propertyName}]`)?.getAttribute("content") ?? "";
 }
+
+export const EXPERIMENTAL_STATION_VALUE_RENDERER = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -19,6 +19,8 @@ importers:
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-quantity': 3.6.0
       '@itwin/ecschema-metadata': 3.6.0
+      '@itwin/ecschema-rpcinterface-common': 3.6.0
+      '@itwin/ecschema-rpcinterface-impl': 3.6.0
       '@itwin/eslint-plugin': 3.6.0
       '@itwin/express-server': 3.6.0
       '@itwin/imodels-access-backend': ^1.0.1
@@ -32,22 +34,24 @@ importers:
       typescript: ^4.7.4
     dependencies:
       '@app/common': link:../common
-      '@itwin/core-backend': 3.6.0_ebb9e634fb1b6af793a5621c3a26fc8d
+      '@itwin/core-backend': 3.6.0_5o46mnh3dnvppe5fmiodujx4ru
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/ecschema-metadata': 3.6.0_36aec1df3d0eda8a7c72f19c718f969b
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
+      '@itwin/ecschema-metadata': 3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm
+      '@itwin/ecschema-rpcinterface-common': 3.6.0_o5vpfkex7tkb5rk7nc4bxftbju
+      '@itwin/ecschema-rpcinterface-impl': 3.6.0_n3ltwfrj7joqpx3doslphhvjoq
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
       '@itwin/express-server': 3.6.0_@itwin+core-backend@3.6.0
-      '@itwin/imodels-access-backend': 1.0.2_786db5f5973001553da8e60d4776f721
-      '@itwin/presentation-backend': 3.6.0_cbb09b996d2ea6b80323574f353bce49
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
+      '@itwin/imodels-access-backend': 1.0.2_pbw3l5mxgaavkpni4yguo5xxee
+      '@itwin/presentation-backend': 3.6.0_zoyjxglnf2tlqazdk5htko6oje
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
       '@types/node': 16.18.12
       dotenv: 10.0.0
       eslint: 7.32.0
       pretty-bytes: 5.6.0
-      ts-node-dev: 2.0.0_88ab94cf50d97c674461df0bd1a62a41
+      ts-node-dev: 2.0.0_rcvzjt2q3f6gordb34f5djrkie
       typescript: 4.9.5
 
   app/common:
@@ -56,17 +60,21 @@ importers:
       '@itwin/core-common': 3.6.0
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-quantity': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0
+      '@itwin/ecschema-rpcinterface-common': 3.6.0
       '@itwin/eslint-plugin': 3.6.0
       '@itwin/presentation-common': 3.6.0
       eslint: ^7.30.0
       typescript: ^4.7.4
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
+      '@itwin/ecschema-metadata': 3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm
+      '@itwin/ecschema-rpcinterface-common': 3.6.0_o5vpfkex7tkb5rk7nc4bxftbju
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
       eslint: 7.32.0
       typescript: 4.9.5
 
@@ -87,7 +95,7 @@ importers:
       ts-node: ^10.9.1
       typescript: ^4.7.4
     dependencies:
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
       '@types/chai': 4.3.4
       '@types/jest-dev-server': 5.0.0
       '@types/mocha': 10.0.1
@@ -99,7 +107,7 @@ importers:
       mocha: 10.2.0
       mocha-junit-reporter: 2.2.0_mocha@10.2.0
       playwright: 1.30.0
-      ts-node: 10.9.1_88ab94cf50d97c674461df0bd1a62a41
+      ts-node: 10.9.1_rcvzjt2q3f6gordb34f5djrkie
       typescript: 4.9.5
 
   app/frontend:
@@ -118,6 +126,8 @@ importers:
       '@itwin/core-orbitgt': 3.6.0
       '@itwin/core-quantity': 3.6.0
       '@itwin/core-react': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0
+      '@itwin/ecschema-rpcinterface-common': 3.6.0
       '@itwin/eslint-plugin': 3.6.0
       '@itwin/imodel-browser-react': ^0.12.1
       '@itwin/imodel-components-react': 3.6.0
@@ -172,31 +182,33 @@ importers:
     dependencies:
       '@app/common': link:../common
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/appui-layout-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
-      '@itwin/appui-react': 3.6.0_afa417267a9ae18aef5e269e92049ca9
-      '@itwin/components-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
+      '@itwin/appui-layout-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
+      '@itwin/appui-react': 3.6.0_v6sbojt2tlqyv326e2pjebe4ve
+      '@itwin/components-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-i18n': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/core-markup': 3.6.0_43451dec4ec68636eae1e1778bd767c4
+      '@itwin/core-markup': 3.6.0_incr33coy2ddn2xb4f3yxv3hyq
       '@itwin/core-orbitgt': 3.6.0
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
-      '@itwin/imodel-browser-react': 0.12.3_react-dom@17.0.2+react@17.0.2
-      '@itwin/imodel-components-react': 3.6.0_5065d60fc3a80fab6f7202509532791f
-      '@itwin/imodels-access-frontend': 1.0.2_ac21a8523e888fde3b76bb286f978124
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
+      '@itwin/ecschema-metadata': 3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm
+      '@itwin/ecschema-rpcinterface-common': 3.6.0_o5vpfkex7tkb5rk7nc4bxftbju
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@itwin/imodel-browser-react': 0.12.3_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/imodel-components-react': 3.6.0_kbs5md6dvah2w33sajijkmtzd4
+      '@itwin/imodels-access-frontend': 1.0.2_vqq2qur6rch54o3wxmug7f4beq
       '@itwin/imodels-client-management': 1.1.0
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-illustrations-react': 1.3.1_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-illustrations-react': 1.3.1_sfoxds7t5ydpegc3knd667wn6m
       '@itwin/itwinui-layouts-css': 0.1.3
-      '@itwin/itwinui-layouts-react': 0.1.3_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
-      '@itwin/presentation-components': 3.6.0_04ab0611fd4e086ffb5b8c341aa253a6
-      '@itwin/presentation-frontend': 3.6.0_fb6599961184f0c951a42de395ee1d2d
+      '@itwin/itwinui-layouts-react': 0.1.3_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
+      '@itwin/presentation-components': 3.6.0_asvqmep5jyeg7623rq2bvistuy
+      '@itwin/presentation-frontend': 3.6.0_7nsztfqrqtymsunefxrzl3q5fu
       '@itwin/presentation-rules-editor-react': link:../../presentation-rules-editor-react
       '@itwin/webgl-compatibility': 3.6.0
       '@microsoft/applicationinsights-web': 2.8.10_tslib@2.5.0
@@ -215,13 +227,13 @@ importers:
       html-webpack-plugin: 5.5.0_webpack@5.75.0
       lz-string: 1.4.4
       monaco-editor: 0.34.1
-      monaco-editor-webpack-plugin: 7.0.1_2904ac1749033f556fc625778550909e
+      monaco-editor-webpack-plugin: 7.0.1_feckyf2jam7vk36gev3ykueqty
       npm-run-all: 4.1.5
       oidc-client: 1.11.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2
-      react-router-dom: 6.8.1_react-dom@17.0.2+react@17.0.2
+      react-redux: 7.2.9_sfoxds7t5ydpegc3knd667wn6m
+      react-router-dom: 6.8.1_sfoxds7t5ydpegc3knd667wn6m
       redux: 4.2.1
       sass: 1.58.0
       sass-loader: 11.1.1_sass@1.58.0+webpack@5.75.0
@@ -229,12 +241,12 @@ importers:
       string-replace-loader: 3.1.0_webpack@5.75.0
       style-loader: 3.3.1_webpack@5.75.0
       terser-webpack-plugin: 5.3.6_webpack@5.75.0
-      ts-node: 10.9.1_88ab94cf50d97c674461df0bd1a62a41
+      ts-node: 10.9.1_rcvzjt2q3f6gordb34f5djrkie
       tslib: 2.5.0
       typescript: 4.9.5
       webpack: 5.75.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
-      webpack-dev-server: 4.11.1_78c1cd1c404fc7ed0a3af68b1f6f4aa1
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
+      webpack-dev-server: 4.11.1_pda42hcaj7d62cr262fr632kue
 
   presentation-rules-editor-react:
     specifiers:
@@ -282,25 +294,25 @@ importers:
       ts-node: ^10.9.1
       typescript: ^4.7.4
     dependencies:
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/components-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
+      '@itwin/components-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-i18n': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/core-orbitgt': 3.6.0
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
-      '@itwin/imodel-components-react': 3.6.0_5065d60fc3a80fab6f7202509532791f
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
-      '@itwin/presentation-components': 3.6.0_04ab0611fd4e086ffb5b8c341aa253a6
-      '@itwin/presentation-frontend': 3.6.0_fb6599961184f0c951a42de395ee1d2d
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@itwin/imodel-components-react': 3.6.0_kbs5md6dvah2w33sajijkmtzd4
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
+      '@itwin/presentation-components': 3.6.0_asvqmep5jyeg7623rq2bvistuy
+      '@itwin/presentation-frontend': 3.6.0_7nsztfqrqtymsunefxrzl3q5fu
       '@itwin/webgl-compatibility': 3.6.0
-      '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
+      '@testing-library/react': 11.2.7_sfoxds7t5ydpegc3knd667wn6m
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 10.0.1
@@ -324,7 +336,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       sinon: 10.0.0
       sinon-chai: 3.7.0_chai@4.3.7+sinon@10.0.0
-      ts-node: 10.9.1_88ab94cf50d97c674461df0bd1a62a41
+      ts-node: 10.9.1_rcvzjt2q3f6gordb34f5djrkie
       typescript: 4.9.5
 
   scripts:
@@ -339,13 +351,13 @@ importers:
       typescript: ^4.7.4
       yargs: ^17.0.1
     dependencies:
-      '@itwin/eslint-plugin': 3.6.0_eslint@7.32.0+typescript@4.9.5
+      '@itwin/eslint-plugin': 3.6.0_jofidmxrjzhj7l6vknpw5ecvfe
       '@types/node': 16.18.12
       '@types/yargs': 17.0.22
       eslint: 7.32.0
       npm-run-all: 4.1.5
       rimraf: 4.1.2
-      ts-node: 10.9.1_88ab94cf50d97c674461df0bd1a62a41
+      ts-node: 10.9.1_rcvzjt2q3f6gordb34f5djrkie
       typescript: 4.9.5
       yargs: 17.6.2
 
@@ -1097,7 +1109,7 @@ packages:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/core-bentley': 3.6.0
 
-  /@itwin/appui-layout-react/3.6.0_480fe2e96b13091113be74cca2ca38ea:
+  /@itwin/appui-layout-react/3.6.0_jah6f2llcmerce56otgkfsry5i:
     resolution: {integrity: sha512-kY7Y3HoXxK04kg8+SQnvwFHNzMxnxgDy4nJmnOMK6qpNqKPdZi9bW0b+uMgzcxCu/GSm1u0QNnfS7Jw2ILX38Q==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1108,18 +1120,18 @@ packages:
     dependencies:
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
       classnames: 2.3.2
       immer: 9.0.6
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
+      react-transition-group: 4.4.5_sfoxds7t5ydpegc3knd667wn6m
     dev: false
 
-  /@itwin/appui-react/3.6.0_afa417267a9ae18aef5e269e92049ca9:
+  /@itwin/appui-react/3.6.0_v6sbojt2tlqyv326e2pjebe4ve:
     resolution: {integrity: sha512-LO+a/M3v7XlRT8nQ/Xy/ibx7xPWpGG1UyyyefjUBgRdBHjrx5csPh1Fp7jcxsMa9lBd4VZdAb7nsNSdjrFQ/xg==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1143,32 +1155,32 @@ packages:
       '@bentley/icons-generic': 1.0.34
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/appui-layout-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
-      '@itwin/components-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
+      '@itwin/appui-layout-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
+      '@itwin/components-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-geometry': 3.6.0
-      '@itwin/core-markup': 3.6.0_43451dec4ec68636eae1e1778bd767c4
+      '@itwin/core-markup': 3.6.0_incr33coy2ddn2xb4f3yxv3hyq
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
       '@itwin/core-telemetry': 3.6.0_@itwin+core-geometry@3.6.0
-      '@itwin/imodel-components-react': 3.6.0_5065d60fc3a80fab6f7202509532791f
+      '@itwin/imodel-components-react': 3.6.0_kbs5md6dvah2w33sajijkmtzd4
       '@itwin/itwinui-css': 0.63.1
       '@itwin/itwinui-icons': 1.16.0
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
-      '@itwin/presentation-components': 3.6.0_04ab0611fd4e086ffb5b8c341aa253a6
-      '@itwin/presentation-frontend': 3.6.0_fb6599961184f0c951a42de395ee1d2d
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
+      '@itwin/presentation-components': 3.6.0_asvqmep5jyeg7623rq2bvistuy
+      '@itwin/presentation-frontend': 3.6.0_7nsztfqrqtymsunefxrzl3q5fu
       classnames: 2.3.2
       immer: 9.0.6
       lodash: 4.17.21
       react: 17.0.2
-      react-dnd: 11.1.3_react-dom@17.0.2+react@17.0.2
+      react-dnd: 11.1.3_sfoxds7t5ydpegc3knd667wn6m
       react-dnd-html5-backend: 11.1.3
       react-dom: 17.0.2_react@17.0.2
-      react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2
+      react-redux: 7.2.9_sfoxds7t5ydpegc3knd667wn6m
       redux: 4.2.1
       rxjs: 6.6.7
     transitivePeerDependencies:
@@ -1182,7 +1194,7 @@ packages:
       inversify: 5.0.5
       reflect-metadata: 0.1.13
 
-  /@itwin/components-react/3.6.0_480fe2e96b13091113be74cca2ca38ea:
+  /@itwin/components-react/3.6.0_jah6f2llcmerce56otgkfsry5i:
     resolution: {integrity: sha512-69pTP62lCBCIAPJ44LIt6rsFjaa7JAc0XDZXT46vsdSZuqoQH6CYdBEc7CNrVvtyHmIdLb6Wzn5uoi+7G8G4yQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1194,10 +1206,10 @@ packages:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
       '@types/shortid': 0.0.29
       callable-instance2: 1.0.0
       classnames: 2.3.2
@@ -1208,18 +1220,18 @@ packages:
       linkify-it: 2.2.0
       lodash: 4.17.21
       react: 17.0.2
-      react-data-grid: 6.0.1_react-dom@17.0.2+react@17.0.2
-      react-dnd: 11.1.3_react-dom@17.0.2+react@17.0.2
+      react-data-grid: 6.0.1_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 11.1.3_sfoxds7t5ydpegc3knd667wn6m
       react-dnd-html5-backend: 11.1.3
       react-dom: 17.0.2_react@17.0.2
       react-highlight-words: 0.17.0_react@17.0.2
-      react-select: 3.2.0_react-dom@17.0.2+react@17.0.2
-      react-window: 1.8.8_react-dom@17.0.2+react@17.0.2
+      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
+      react-window: 1.8.8_sfoxds7t5ydpegc3knd667wn6m
       rxjs: 6.6.7
       shortid: 2.2.16
       ts-key-enum: 2.0.12
 
-  /@itwin/core-backend/3.6.0_ebb9e634fb1b6af793a5621c3a26fc8d:
+  /@itwin/core-backend/3.6.0_5o46mnh3dnvppe5fmiodujx4ru:
     resolution: {integrity: sha512-9XR3mLpgvweRwTpApjm/jkcn0q6hFTa3g6+5orMNRoj7/W0F7wQwMD2/x5qNIxdj18X1L6G91cj7rSAejQjO0w==}
     engines: {node: '>=12.22.0 < 14.0 || >=14.17.0 < 19.0'}
     peerDependencies:
@@ -1235,7 +1247,7 @@ packages:
       '@bentley/imodeljs-native': 3.6.7
       '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-telemetry': 3.6.0_@itwin+core-geometry@3.6.0
       '@itwin/object-storage-azure': 1.4.0
@@ -1258,7 +1270,7 @@ packages:
   /@itwin/core-bentley/3.6.0:
     resolution: {integrity: sha512-Ne4CaP/BB8KjJXFwkJA8F9k5+jHRBjDL9y1GwaTM6PbbtDO2piM4mczyJG66cwhUraM7bSbtdNXGVkBfb1fZ9w==}
 
-  /@itwin/core-common/3.6.0_a80157360e08c274552ebc4b42a3fafb:
+  /@itwin/core-common/3.6.0_vaavonqobdbhivjoxrfufi727m:
     resolution: {integrity: sha512-0CKuN91+qZdMSbM0QkEd970fuCjjWwtYu2KrOrk3nkkwk+eKnwDois8Wmsn0Q6QZx0l3GOOhdTX86pA+UTQtCw==}
     peerDependencies:
       '@itwin/core-bentley': ^3.6.0
@@ -1273,7 +1285,7 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/core-frontend/3.6.0_577d3d30be38caac2b5c310e4690b8b4:
+  /@itwin/core-frontend/3.6.0_k56t2mf6hdfkyk24gehenefywq:
     resolution: {integrity: sha512-fu2NbEQL+lAresrKyKatwA9EzwMxmlcy0k0sP5YhuGk7OT/VKu3ontE9Yf/d8vwJj4eZCEldepqSlDA3rfl8lw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1287,7 +1299,7 @@ packages:
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-i18n': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/core-orbitgt': 3.6.0
@@ -1329,7 +1341,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@itwin/core-markup/3.6.0_43451dec4ec68636eae1e1778bd767c4:
+  /@itwin/core-markup/3.6.0_incr33coy2ddn2xb4f3yxv3hyq:
     resolution: {integrity: sha512-Av19zP6vtHh7qMFwYev1p/6PyhXMqGlwCEZ7B0aFbO3XYf9O/uocmSMKamOKurnn/6/ahiKZatrIy8QGw6p7VQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.6.0
@@ -1338,8 +1350,8 @@ packages:
       '@itwin/core-geometry': ^3.6.0
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-geometry': 3.6.0
       '@svgdotjs/svg.js': 3.0.13
     dev: false
@@ -1354,7 +1366,7 @@ packages:
     dependencies:
       '@itwin/core-bentley': 3.6.0
 
-  /@itwin/core-react/3.6.0_b6f562b8abe0339220b9b0348a1cbf2f:
+  /@itwin/core-react/3.6.0_w32wfofl4azzeifzwa2iuhf7f4:
     resolution: {integrity: sha512-3kcc2OVeoh0G7T8X4K4gLHEbMnwh5rk7tg+g+qF+c2pQfjCkOZmbL+2AUKNTtIISdkdW6tl3dI+02OgpQLyqFg==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1366,26 +1378,26 @@ packages:
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
       '@itwin/core-bentley': 3.6.0
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
       classnames: 2.3.2
       dompurify: 2.4.3
       lodash: 4.17.21
       react: 17.0.2
       react-autosuggest: 10.1.0_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-select: 3.2.0_react-dom@17.0.2+react@17.0.2
+      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
       resize-observer-polyfill: 1.5.1
 
   /@itwin/core-telemetry/3.6.0_@itwin+core-geometry@3.6.0:
     resolution: {integrity: sha512-ZJHiJyvpAwljpelRXAVLLb3DLWR/c3iVgTUHVshkt9SRyou7GFtyMuySXjChkpXwL5v7LZHmEIQeVOovoqaSYA==}
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
     transitivePeerDependencies:
       - '@itwin/core-geometry'
       - debug
 
-  /@itwin/ecschema-metadata/3.6.0_36aec1df3d0eda8a7c72f19c718f969b:
+  /@itwin/ecschema-metadata/3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm:
     resolution: {integrity: sha512-JhCO+NQtMs9Av2sQAMCRMfS7JZGBZLiOI0tJ5TMSb3W6pwXqYQcGXO4hDcrRwgmLpK+vXZhU2bww+eYYTKFg9Q==}
     peerDependencies:
       '@itwin/core-bentley': ^3.6.0
@@ -1396,20 +1408,52 @@ packages:
       almost-equal: 1.1.0
     dev: false
 
-  /@itwin/eslint-plugin/3.6.0_eslint@7.32.0+typescript@4.9.5:
+  /@itwin/ecschema-rpcinterface-common/3.6.0_o5vpfkex7tkb5rk7nc4bxftbju:
+    resolution: {integrity: sha512-FN2o5IZ0mhYNysJCkDvqp6qdJjhZ+CbcVZTuJUlwV53D0UYH8HfU6GLgcclOvJlhU54v9ecdbR72zBMY4iewGw==}
+    peerDependencies:
+      '@itwin/core-bentley': 3.6.0
+      '@itwin/core-common': 3.6.0
+      '@itwin/core-geometry': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0
+    dependencies:
+      '@itwin/core-bentley': 3.6.0
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-geometry': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm
+    dev: false
+
+  /@itwin/ecschema-rpcinterface-impl/3.6.0_n3ltwfrj7joqpx3doslphhvjoq:
+    resolution: {integrity: sha512-9QKWvWLzRfv3MnruFkNbEJ0v6fDpzWpZ0VQrBRqyApbTQ+2Eau3l9L5UgTu2Q/8S9pZxc61Qa7OxrLcml3g2sA==}
+    peerDependencies:
+      '@itwin/core-backend': 3.6.0
+      '@itwin/core-bentley': 3.6.0
+      '@itwin/core-common': 3.6.0
+      '@itwin/core-geometry': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0
+      '@itwin/ecschema-rpcinterface-common': 3.6.0
+    dependencies:
+      '@itwin/core-backend': 3.6.0_5o46mnh3dnvppe5fmiodujx4ru
+      '@itwin/core-bentley': 3.6.0
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-geometry': 3.6.0
+      '@itwin/ecschema-metadata': 3.6.0_g2xmdxz5b3niu7ds6gohdd4wtm
+      '@itwin/ecschema-rpcinterface-common': 3.6.0_o5vpfkex7tkb5rk7nc4bxftbju
+    dev: false
+
+  /@itwin/eslint-plugin/3.6.0_jofidmxrjzhj7l6vknpw5ecvfe:
     resolution: {integrity: sha512-PFRVfyF14kaEF+noc5sbVKu6dP83DHDWBL8EK9Lyr70gOqeNuxqrsOLX518ubA/8j9jORLT79QzpIMKyVjdGhA==}
     hasBin: true
     peerDependencies:
       eslint: ^7.0.0
       typescript: ^3.7.0 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.31.2_e955d08c4711e9f6d003505f8de5fa4c
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.9.5
+      '@typescript-eslint/eslint-plugin': 4.31.2_5fk5bdchchu7nuadkbpy3zp2jq
+      '@typescript-eslint/parser': 4.31.2_jofidmxrjzhj7l6vknpw5ecvfe
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
-      eslint-import-resolver-typescript: 2.7.1_ee2ddb12623c985c36290f985ad5559c
-      eslint-plugin-deprecation: 1.2.1_eslint@7.32.0+typescript@4.9.5
-      eslint-plugin-import: 2.23.4_aefb9eb6c2197b2c8e20a5198dd58693
+      eslint-import-resolver-typescript: 2.7.1_5yw5wetchsmfynrjb6mfvvkvtq
+      eslint-plugin-deprecation: 1.2.1_jofidmxrjzhj7l6vknpw5ecvfe
+      eslint-plugin-import: 2.23.4_v35z5nwcdf5szdrauumy3vmgsm
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3_eslint@7.32.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.32.0
@@ -1428,7 +1472,7 @@ packages:
     peerDependencies:
       '@itwin/core-backend': 3.6.0
     dependencies:
-      '@itwin/core-backend': 3.6.0_ebb9e634fb1b6af793a5621c3a26fc8d
+      '@itwin/core-backend': 3.6.0_5o46mnh3dnvppe5fmiodujx4ru
       express: 4.18.2
       express-ws: 5.0.2_express@4.18.2
     transitivePeerDependencies:
@@ -1437,21 +1481,21 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@itwin/imodel-browser-react/0.12.3_react-dom@17.0.2+react@17.0.2:
+  /@itwin/imodel-browser-react/0.12.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-6StRaAn/QzlRpFLLRiY9u95LUlQDjTYt34vxxxOtlK2qWR5jt1zU4YBYaJXV08dtJHUh9kUdyNpA0v+KUcus8w==}
     peerDependencies:
       react: ^16.13.0 || ^17.0.2
       react-dom: ^16.13.0 || ^17.0.2
     dependencies:
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
       classnames: 2.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-intersection-observer: 8.34.0_react@17.0.2
     dev: false
 
-  /@itwin/imodel-components-react/3.6.0_5065d60fc3a80fab6f7202509532791f:
+  /@itwin/imodel-components-react/3.6.0_kbs5md6dvah2w33sajijkmtzd4:
     resolution: {integrity: sha512-xsV94M+cBU1EBHGuKCBeT/SsJuezFf6Y1YVumbZPKEw9qX1M0NE+z3DepZawV4Ql/iadgfoXqUDR9+dO2tlMuw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1467,15 +1511,15 @@ packages:
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/components-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
+      '@itwin/components-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-geometry': 3.6.0
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
       callable-instance2: 1.0.0
       classnames: 2.3.2
       eventemitter2: 5.0.1
@@ -1485,23 +1529,23 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       ts-key-enum: 2.0.12
 
-  /@itwin/imodels-access-backend/1.0.2_786db5f5973001553da8e60d4776f721:
+  /@itwin/imodels-access-backend/1.0.2_pbw3l5mxgaavkpni4yguo5xxee:
     resolution: {integrity: sha512-pEP+Sycbw7kFyRuMn1ia8E6Qcw/aIWjP8LWRKj4bPCeIOrL+FCqOl5dhsCHGAJltlA0QIavKxgm7jzBRUZfNWA==}
     peerDependencies:
       '@itwin/core-backend': ^3.0.0
       '@itwin/core-bentley': ^3.0.0
       '@itwin/core-common': ^3.0.0
     dependencies:
-      '@itwin/core-backend': 3.6.0_ebb9e634fb1b6af793a5621c3a26fc8d
+      '@itwin/core-backend': 3.6.0_5o46mnh3dnvppe5fmiodujx4ru
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/imodels-client-authoring': 1.1.0
     transitivePeerDependencies:
       - debug
       - encoding
     dev: false
 
-  /@itwin/imodels-access-frontend/1.0.2_ac21a8523e888fde3b76bb286f978124:
+  /@itwin/imodels-access-frontend/1.0.2_vqq2qur6rch54o3wxmug7f4beq:
     resolution: {integrity: sha512-ya20mAwvGltFXH5hguy39laQU1Ku1hHMU7KSSGgxKlN8WSrpe4haM3nT0FR5Fj+XUBdQ+c7T/V1+Kg27uz4BFw==}
     peerDependencies:
       '@itwin/core-bentley': ^3.0.0
@@ -1509,8 +1553,8 @@ packages:
       '@itwin/core-frontend': ^3.0.0
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/imodels-client-management': 1.1.0
     transitivePeerDependencies:
       - debug
@@ -1537,7 +1581,7 @@ packages:
   /@itwin/itwinui-css/0.63.1:
     resolution: {integrity: sha512-GWXRaaYBxbmIpXncrf6yOeqvyIaQWmtdx8lJ/UehT+vjahcklO00+dFEzWBboFdE/4ftDOqurqbuiDcNf2lugQ==}
 
-  /@itwin/itwinui-icons-react/1.16.0_react-dom@17.0.2+react@17.0.2:
+  /@itwin/itwinui-icons-react/1.16.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-0jlfxz+8qy2h13UuVfh5mgtK3NCv5hagphcjPA4XC4Qe4FDG9p3ku50jLTXyBOTZTZWrd7aTMdZjrMIlJyEMbw==}
     peerDependencies:
       react: '>=16.8.6'
@@ -1550,7 +1594,7 @@ packages:
     resolution: {integrity: sha512-m3s28MitTRtCo7hAIjMB7787KGsjvPhxN9QucmTaKXxDJLahb51fqq4YXgZBpyLw39tbAMETXmbdEdzN6HnK4w==}
     dev: false
 
-  /@itwin/itwinui-illustrations-react/1.3.1_react-dom@17.0.2+react@17.0.2:
+  /@itwin/itwinui-illustrations-react/1.3.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-hIZwYwd1qmyjt5yiL8Lg6E3CpgeLxGOnb4dVktoM+h3h5zSmgjhm2qFk+RqgsqV+dy0Fb2cs1jH4Jup9jWY9pA==}
     peerDependencies:
       react: '>=16.8.6'
@@ -1565,7 +1609,7 @@ packages:
       '@itwin/itwinui-css': 0.63.1
     dev: false
 
-  /@itwin/itwinui-layouts-react/0.1.3_react-dom@17.0.2+react@17.0.2:
+  /@itwin/itwinui-layouts-react/0.1.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-5wT/05e8yiNwz2G1iBXGQgGo4Xm9hoN3yWYGdoUD84KdQC8ko7HLhAAnIQFty/hvZAOZCkpNLIdlWUtyDGhl6Q==}
     peerDependencies:
       react: '>=16.8.6'
@@ -1577,22 +1621,22 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@itwin/itwinui-react/1.46.0_react-dom@17.0.2+react@17.0.2:
+  /@itwin/itwinui-react/1.46.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Leb0KFC7p6Gx9Wx90fYcH8KXeBk9zEvbhrMy5mMhPehA2HnQVvOO/tcwh2SKN+9KZdEB3J8hGArzNeE23Qx85A==}
     peerDependencies:
       react: '>=16.8.6 < 19.0.0'
       react-dom: '>=16.8.6 < 19.0.0'
     dependencies:
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-illustrations-react': 1.3.1_react-dom@17.0.2+react@17.0.2
-      '@tippyjs/react': 4.2.6_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-illustrations-react': 1.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
       '@types/react-table': 7.7.14
       classnames: 2.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-table: 7.8.0_react@17.0.2
-      react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
+      react-transition-group: 4.4.5_sfoxds7t5ydpegc3knd667wn6m
 
   /@itwin/object-storage-azure/1.4.0:
     resolution: {integrity: sha512-/vREtCo/h+Np5RlmLP8AHZ2Yb7rc77ywKj8jNCwoV/uyg9ea3r+OaoBJX/0w9epQwjGRsLEXwFFywXB5IUQJ7A==}
@@ -1619,7 +1663,7 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/presentation-backend/3.6.0_cbb09b996d2ea6b80323574f353bce49:
+  /@itwin/presentation-backend/3.6.0_zoyjxglnf2tlqazdk5htko6oje:
     resolution: {integrity: sha512-2K/A9ddyr4W5XuwwMubbWBLePoF0SuxXDSGwziYUmQlFCNyzFfwlwy0C7WO9grv5PzeOOnVDIx4e8RWEJ/7PBA==}
     peerDependencies:
       '@itwin/core-backend': ^3.6.0
@@ -1628,16 +1672,16 @@ packages:
       '@itwin/core-quantity': ^3.6.0
       '@itwin/presentation-common': ^3.6.0
     dependencies:
-      '@itwin/core-backend': 3.6.0_ebb9e634fb1b6af793a5621c3a26fc8d
+      '@itwin/core-backend': 3.6.0_5o46mnh3dnvppe5fmiodujx4ru
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
       object-hash: 1.3.1
       semver: 7.3.8
     dev: false
 
-  /@itwin/presentation-common/3.6.0_6a89fa727f0bdda2ed60d93d15689fb8:
+  /@itwin/presentation-common/3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa:
     resolution: {integrity: sha512-mE/kR9+S6UGSBwlH21b71+ULWBNrZqAddP7O62PpB2qRpz+d0blZCsGiq6sqN8gkmPoFlqEGSf8f16bO8IsWEw==}
     peerDependencies:
       '@itwin/core-bentley': ^3.6.0
@@ -1645,10 +1689,10 @@ packages:
       '@itwin/core-quantity': ^3.6.0
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
 
-  /@itwin/presentation-components/3.6.0_04ab0611fd4e086ffb5b8c341aa253a6:
+  /@itwin/presentation-components/3.6.0_asvqmep5jyeg7623rq2bvistuy:
     resolution: {integrity: sha512-YNFi1euqjsMvnw5GaDALTnKnEzyTHnSk5pxoIEruM5GPSYxe6iU/pU83bi7CatZKgRbS6gu6QYpQ8MBqfhXPGA==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.6.0
@@ -1664,28 +1708,28 @@ packages:
       react-dom: ^17.0.0
     dependencies:
       '@itwin/appui-abstract': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/components-react': 3.6.0_480fe2e96b13091113be74cca2ca38ea
+      '@itwin/components-react': 3.6.0_jah6f2llcmerce56otgkfsry5i
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
-      '@itwin/core-react': 3.6.0_b6f562b8abe0339220b9b0348a1cbf2f
-      '@itwin/imodel-components-react': 3.6.0_5065d60fc3a80fab6f7202509532791f
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
+      '@itwin/core-react': 3.6.0_w32wfofl4azzeifzwa2iuhf7f4
+      '@itwin/imodel-components-react': 3.6.0_kbs5md6dvah2w33sajijkmtzd4
       '@itwin/itwinui-css': 0.63.1
-      '@itwin/itwinui-icons-react': 1.16.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/itwinui-react': 1.46.0_react-dom@17.0.2+react@17.0.2
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
-      '@itwin/presentation-frontend': 3.6.0_fb6599961184f0c951a42de395ee1d2d
+      '@itwin/itwinui-icons-react': 1.16.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/itwinui-react': 1.46.0_sfoxds7t5ydpegc3knd667wn6m
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
+      '@itwin/presentation-frontend': 3.6.0_7nsztfqrqtymsunefxrzl3q5fu
       classnames: 2.3.2
       fast-deep-equal: 3.1.3
       fast-sort: 3.2.1
       micro-memoize: 4.0.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-select: 3.2.0_react-dom@17.0.2+react@17.0.2
-      react-select-async-paginate: 0.5.3_c0582c9c36ad2eb92f1bac26b7fcc797
+      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
+      react-select-async-paginate: 0.5.3_ybmczhbwvuxlsly3vqtlp7ghs4
       rxjs: 6.6.7
 
-  /@itwin/presentation-frontend/3.6.0_fb6599961184f0c951a42de395ee1d2d:
+  /@itwin/presentation-frontend/3.6.0_7nsztfqrqtymsunefxrzl3q5fu:
     resolution: {integrity: sha512-ZdvBb799qD5yyZDLlexQu7WZs9jAqtnPoZNluuAa2AREivqp9lL4eBo+lJF6uqGRsbvlpH5K2AIzTCEkSfIHBA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.6.0
@@ -1695,10 +1739,10 @@ packages:
       '@itwin/presentation-common': ^3.6.0
     dependencies:
       '@itwin/core-bentley': 3.6.0
-      '@itwin/core-common': 3.6.0_a80157360e08c274552ebc4b42a3fafb
-      '@itwin/core-frontend': 3.6.0_577d3d30be38caac2b5c310e4690b8b4
+      '@itwin/core-common': 3.6.0_vaavonqobdbhivjoxrfufi727m
+      '@itwin/core-frontend': 3.6.0_k56t2mf6hdfkyk24gehenefywq
       '@itwin/core-quantity': 3.6.0_@itwin+core-bentley@3.6.0
-      '@itwin/presentation-common': 3.6.0_6a89fa727f0bdda2ed60d93d15689fb8
+      '@itwin/presentation-common': 3.6.0_nke7u4t7bpo2f3la3e6rk2e7xa
 
   /@itwin/webgl-compatibility/3.6.0:
     resolution: {integrity: sha512-xhc80KbUbQpEEjYJFvstLpMAguj6+A0AQUqiv1RHdz6QWfuECBC8zlTqA772zuMtZ497OM6Nr+GUkidkmjHsog==}
@@ -2028,7 +2072,7 @@ packages:
       pretty-format: 26.6.2
     dev: true
 
-  /@testing-library/react/11.2.7_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react/11.2.7_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -2041,7 +2085,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@tippyjs/react/4.2.6_react-dom@17.0.2+react@17.0.2:
+  /@tippyjs/react/4.2.6_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==}
     peerDependencies:
       react: '>=16.8'
@@ -2373,7 +2417,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: false
 
-  /@typescript-eslint/eslint-plugin/4.31.2_e955d08c4711e9f6d003505f8de5fa4c:
+  /@typescript-eslint/eslint-plugin/4.31.2_5fk5bdchchu7nuadkbpy3zp2jq:
     resolution: {integrity: sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2384,8 +2428,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.31.2_eslint@7.32.0+typescript@4.9.5
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.9.5
+      '@typescript-eslint/experimental-utils': 4.31.2_jofidmxrjzhj7l6vknpw5ecvfe
+      '@typescript-eslint/parser': 4.31.2_jofidmxrjzhj7l6vknpw5ecvfe
       '@typescript-eslint/scope-manager': 4.31.2
       debug: 4.3.4
       eslint: 7.32.0
@@ -2397,7 +2441,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@4.9.5:
+  /@typescript-eslint/experimental-utils/3.10.1_jofidmxrjzhj7l6vknpw5ecvfe:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2413,7 +2457,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/experimental-utils/4.31.2_eslint@7.32.0+typescript@4.9.5:
+  /@typescript-eslint/experimental-utils/4.31.2_jofidmxrjzhj7l6vknpw5ecvfe:
     resolution: {integrity: sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2430,7 +2474,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/parser/4.31.2_eslint@7.32.0+typescript@4.9.5:
+  /@typescript-eslint/parser/4.31.2_jofidmxrjzhj7l6vknpw5ecvfe:
     resolution: {integrity: sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2624,14 +2668,14 @@ packages:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webpack-cli/configtest/1.2.0_78c1cd1c404fc7ed0a3af68b1f6f4aa1:
+  /@webpack-cli/configtest/1.2.0_pda42hcaj7d62cr262fr632kue:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.75.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
     dev: false
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
@@ -2640,10 +2684,10 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
     dev: false
 
-  /@webpack-cli/serve/1.7.0_a0f80309603fe203d23e6cdc97521dfe:
+  /@webpack-cli/serve/1.7.0_ud4agclah7rahur6ntojouq57y:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
     peerDependencies:
       webpack-cli: 4.x.x
@@ -2652,8 +2696,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
-      webpack-dev-server: 4.11.1_78c1cd1c404fc7ed0a3af68b1f6f4aa1
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
+      webpack-dev-server: 4.11.1_pda42hcaj7d62cr262fr632kue
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -4006,7 +4050,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-import-resolver-typescript/2.7.1_ee2ddb12623c985c36290f985ad5559c:
+  /eslint-import-resolver-typescript/2.7.1_5yw5wetchsmfynrjb6mfvvkvtq:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4015,7 +4059,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 7.32.0
-      eslint-plugin-import: 2.23.4_aefb9eb6c2197b2c8e20a5198dd58693
+      eslint-plugin-import: 2.23.4_v35z5nwcdf5szdrauumy3vmgsm
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.1
@@ -4023,7 +4067,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-module-utils/2.7.4_87a7f06d8747e7e20da3def72791dfc6:
+  /eslint-module-utils/2.7.4_q6t7a3mhi7t6ednd333speo7yy:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4044,21 +4088,21 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.9.5
+      '@typescript-eslint/parser': 4.31.2_jofidmxrjzhj7l6vknpw5ecvfe
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
-      eslint-import-resolver-typescript: 2.7.1_ee2ddb12623c985c36290f985ad5559c
+      eslint-import-resolver-typescript: 2.7.1_5yw5wetchsmfynrjb6mfvvkvtq
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-deprecation/1.2.1_eslint@7.32.0+typescript@4.9.5:
+  /eslint-plugin-deprecation/1.2.1_jofidmxrjzhj7l6vknpw5ecvfe:
     resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
       typescript: ^3.7.5 || ^4.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.32.0+typescript@4.9.5
+      '@typescript-eslint/experimental-utils': 3.10.1_jofidmxrjzhj7l6vknpw5ecvfe
       eslint: 7.32.0
       tslib: 1.14.1
       tsutils: 3.21.0_typescript@4.9.5
@@ -4066,7 +4110,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-import/2.23.4_aefb9eb6c2197b2c8e20a5198dd58693:
+  /eslint-plugin-import/2.23.4_v35z5nwcdf5szdrauumy3vmgsm:
     resolution: {integrity: sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4076,14 +4120,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.31.2_eslint@7.32.0+typescript@4.9.5
+      '@typescript-eslint/parser': 4.31.2_jofidmxrjzhj7l6vknpw5ecvfe
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
-      eslint-module-utils: 2.7.4_87a7f06d8747e7e20da3def72791dfc6
+      eslint-module-utils: 2.7.4_q6t7a3mhi7t6ednd333speo7yy
       find-up: 2.1.0
       has: 1.0.3
       is-core-module: 2.11.0
@@ -5934,7 +5978,7 @@ packages:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  /monaco-editor-webpack-plugin/7.0.1_2904ac1749033f556fc625778550909e:
+  /monaco-editor-webpack-plugin/7.0.1_feckyf2jam7vk36gev3ykueqty:
     resolution: {integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==}
     peerDependencies:
       monaco-editor: '>= 0.31.0'
@@ -6685,7 +6729,7 @@ packages:
       section-iterator: 2.0.0
       shallow-equal: 1.2.1
 
-  /react-data-grid/6.0.1_react-dom@17.0.2+react@17.0.2:
+  /react-data-grid/6.0.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-a4OGEjWTOCJ64GvXwTXEHDEQ8iXZ8Xk30izUKyAVmP5q+Q2AOTMq/qUcHQwpL+XJ81/vTPTIhR//ELjjzYGwFQ==}
     peerDependencies:
       react: ^16.0.0
@@ -6699,7 +6743,7 @@ packages:
     dependencies:
       dnd-core: 11.1.3
 
-  /react-dnd/11.1.3_react-dom@17.0.2+react@17.0.2:
+  /react-dnd/11.1.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==}
     peerDependencies:
       react: '>= 16.9.0'
@@ -6748,7 +6792,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-is-mounted-hook/1.1.2_react-dom@17.0.2+react@17.0.2:
+  /react-is-mounted-hook/1.1.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-yjq3Tj34CiFcdVOS/h6JerWLOLdJqEGKMNpTHc4kWebzz2YtIpgqMRrqxdmQhewM1KJREojdAV2tsNvBsUWyhA==}
     peerDependencies:
       react: ^16.8.6 || ^17
@@ -6763,7 +6807,7 @@ packages:
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  /react-redux/7.2.9_react-dom@17.0.2+react@17.0.2:
+  /react-redux/7.2.9_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18
@@ -6785,7 +6829,7 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /react-router-dom/6.8.1_react-dom@17.0.2+react@17.0.2:
+  /react-router-dom/6.8.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6808,7 +6852,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-select-async-paginate/0.5.3_c0582c9c36ad2eb92f1bac26b7fcc797:
+  /react-select-async-paginate/0.5.3_ybmczhbwvuxlsly3vqtlp7ghs4:
     resolution: {integrity: sha512-SWX1twi/jzViDpQa1nS+xyjrFtn9RBezbL4aIjcJXCABKMY+8JhH4iAKqAW3pryZbm439/DaMtQeZADH17v7bQ==}
     peerDependencies:
       react: ^16.14.0 || ^17.0.0
@@ -6817,13 +6861,13 @@ packages:
       '@babel/runtime': 7.20.13
       '@seznam/compose-react-refs': 1.0.6
       react: 17.0.2
-      react-is-mounted-hook: 1.1.2_react-dom@17.0.2+react@17.0.2
-      react-select: 3.2.0_react-dom@17.0.2+react@17.0.2
+      react-is-mounted-hook: 1.1.2_sfoxds7t5ydpegc3knd667wn6m
+      react-select: 3.2.0_sfoxds7t5ydpegc3knd667wn6m
       sleep-promise: 9.1.0
     transitivePeerDependencies:
       - react-dom
 
-  /react-select/3.2.0_react-dom@17.0.2+react@17.0.2:
+  /react-select/3.2.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6838,7 +6882,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-input-autosize: 3.0.0_react@17.0.2
-      react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
+      react-transition-group: 4.4.5_sfoxds7t5ydpegc3knd667wn6m
 
   /react-table/7.8.0_react@17.0.2:
     resolution: {integrity: sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==}
@@ -6852,7 +6896,7 @@ packages:
     dependencies:
       object-assign: 3.0.0
 
-  /react-transition-group/4.4.5_react-dom@17.0.2+react@17.0.2:
+  /react-transition-group/4.4.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
       react: '>=16.6.0'
@@ -6865,7 +6909,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
 
-  /react-window/1.8.8_react-dom@17.0.2+react@17.0.2:
+  /react-window/1.8.8_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==}
     engines: {node: '>8.0.0'}
     peerDependencies:
@@ -7779,7 +7823,7 @@ packages:
   /ts-key-enum/2.0.12:
     resolution: {integrity: sha512-Ety4IvKMaeG34AyXMp5r11XiVZNDRL+XWxXbVVJjLvq2vxKRttEANBE7Za1bxCAZRdH2/sZT6jFyyTWxXz28hw==}
 
-  /ts-node-dev/2.0.0_88ab94cf50d97c674461df0bd1a62a41:
+  /ts-node-dev/2.0.0_rcvzjt2q3f6gordb34f5djrkie:
     resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
     engines: {node: '>=0.8.0'}
     hasBin: true
@@ -7798,7 +7842,7 @@ packages:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.1_88ab94cf50d97c674461df0bd1a62a41
+      ts-node: 10.9.1_rcvzjt2q3f6gordb34f5djrkie
       tsconfig: 7.0.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -7807,7 +7851,7 @@ packages:
       - '@types/node'
     dev: false
 
-  /ts-node/10.9.1_88ab94cf50d97c674461df0bd1a62a41:
+  /ts-node/10.9.1_rcvzjt2q3f6gordb34f5djrkie:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -8089,7 +8133,7 @@ packages:
     engines: {node: '>=10.4'}
     dev: true
 
-  /webpack-cli/4.10.0_a03037929752522b8c382995bf0923ba:
+  /webpack-cli/4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8110,9 +8154,9 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_78c1cd1c404fc7ed0a3af68b1f6f4aa1
+      '@webpack-cli/configtest': 1.2.0_pda42hcaj7d62cr262fr632kue
       '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
-      '@webpack-cli/serve': 1.7.0_a0f80309603fe203d23e6cdc97521dfe
+      '@webpack-cli/serve': 1.7.0_ud4agclah7rahur6ntojouq57y
       colorette: 2.0.19
       commander: 7.2.0
       cross-spawn: 7.0.3
@@ -8121,7 +8165,7 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.1
       webpack: 5.75.0_webpack-cli@4.10.0
-      webpack-dev-server: 4.11.1_78c1cd1c404fc7ed0a3af68b1f6f4aa1
+      webpack-dev-server: 4.11.1_pda42hcaj7d62cr262fr632kue
       webpack-merge: 5.8.0
     dev: false
 
@@ -8139,7 +8183,7 @@ packages:
       webpack: 5.75.0_webpack-cli@4.10.0
     dev: false
 
-  /webpack-dev-server/4.11.1_78c1cd1c404fc7ed0a3af68b1f6f4aa1:
+  /webpack-dev-server/4.11.1_pda42hcaj7d62cr262fr632kue:
     resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -8178,7 +8222,7 @@ packages:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack: 5.75.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
       webpack-dev-middleware: 5.3.3_webpack@5.75.0
       ws: 8.12.0
     transitivePeerDependencies:
@@ -8241,7 +8285,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.6_webpack@5.75.0
       watchpack: 2.4.0
-      webpack-cli: 4.10.0_a03037929752522b8c382995bf0923ba
+      webpack-cli: 4.10.0_uaydpeuxkjjcxdbyfgk36cjdxi
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
- Start using `ECSchemaRpcInterface` - we'll soon need it for formatting values on the frontend anyway. GPB has it registered, so we only need to make it available on our local backend and frontend.

- Register an experimental "Station" value renderer (only has effect when being assigned as a renderer to a property of some element that has a related `LinearReferencing.LinearlyReferencedLocation` aspect. The renderer doesn't care what property it's being assigned to as it doesn't use any property of the element itself. Ideally, we'd create a custom property for the element and assign this renderer to it.

**Example rules:**
```json
{
  "id": "StationProperties",
  "rules": [
    {
      "ruleType": "RootNodes",
      "specifications": [
        {
          "specType": "InstanceNodesOfSpecificClasses",
          "classes": {
            "schemaName": "CivilPhysical",
            "classNames": [
              "Course"
            ]
          },
          "arePolymorphic": true,
          "groupByClass": false,
          "groupByLabel": false
        }
      ]
    },
    {
      "ruleType": "Content",
      "specifications": [
        {
          "specType": "SelectedNodeInstances"
        }
      ]
    },
    {
      "ruleType": "ContentModifier",
      "class": {
        "schemaName": "CivilPhysical",
        "className": "Course"
      },
      "propertyOverrides": [
        {
          "name": "UserLabel",
          "labelOverride": "Station Value",
          "renderer": {
            "rendererName": "Station"
          }
        }
      ]
    }
  ]
}
```

**Result in property grid:**
![image](https://user-images.githubusercontent.com/35135765/221181574-2566e7aa-c8b3-4268-a3a4-ee2abb794b7d.png)
