### PR TITLE
Install playwright browsers in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,10 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    - name: Install playwright browsers
+      run: npx playwright install
+      working-directory: ./app/e2e-tests
+
     - name: ESLint
       run: npm run lint
 


### PR DESCRIPTION
Hopefully will fix this: https://github.com/iTwin/presentation-rules-editor/actions/runs/4608694785/jobs/8144818068?pr=133

```
  1) "before all" hook in "{root}":
     browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium-1045/chrome-linux/chrome
╔═════════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just installed or updated. ║
║ Please run the following command to download new browsers:              ║
║                                                                         ║
║     npx playwright install                                              ║
║                                                                         ║
║ <3 Playwright Team                                                      ║
╚═════════════════════════════════════════════════════════════════════════╝
      at setupBrowser (src/setup.ts:89:28)
      at Context.<anonymous> (src/setup.ts:27:5)
```