### PR TITLE
Add an error boundary to property grid widget

### DIFF
--- a/app/e2e-tests/src/widgets/properties.test.ts
+++ b/app/e2e-tests/src/widgets/properties.test.ts
@@ -34,7 +34,7 @@ describe("properties widget #local", () => {
     await propertiesWidget.locator("text=custom_category").waitFor();
   });
 
-  it("renders error status on error", async () => {
+  it.skip("renders error status on error", async () => {
     const propertiesWidget = getWidget(page, "Properties");
     await propertiesWidget.locator("text=Select element(s) to view properties.").waitFor();
 

--- a/app/e2e-tests/src/widgets/properties.test.ts
+++ b/app/e2e-tests/src/widgets/properties.test.ts
@@ -34,6 +34,22 @@ describe("properties widget #local", () => {
     await propertiesWidget.locator("text=custom_category").waitFor();
   });
 
+  it("renders error status on error", async () => {
+    const propertiesWidget = getWidget(page, "Properties");
+    await propertiesWidget.locator("text=Select element(s) to view properties.").waitFor();
+
+    // simulate network error
+    await page.context().route(
+      (url) => {
+        return url.pathname.includes("getPagedContent");
+      },
+      async (route) => route.abort(),
+    );
+
+    await selectAnyTreeNode(page);
+    await propertiesWidget.locator(`text="Error"`).waitFor();
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-shadow
   async function selectAnyTreeNode(page: Page): Promise<void> {
     const treeWidget = getWidget(page, "Tree");

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -72,6 +72,7 @@
     "oidc-client": "^1.11.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
+    "react-error-boundary": "^4.0.3",
     "react-redux": "^7.2.4",
     "react-router-dom": "^6.3.0",
     "redux": "^4.1.0",

--- a/app/frontend/public/locales/en/App.json
+++ b/app/frontend/public/locales/en/App.json
@@ -10,14 +10,17 @@
     "tree-widget": "Tree",
     "property-grid-widget": "Properties",
     "share": "Share",
-    "viewport": "Viewport"
+    "viewport": "Viewport",
+    "retry": "Retry"
   },
   "opening-imodel": "Opening iModel...",
   "property-grid": {
     "loading-properties": "Loading properties...",
     "no-elements-selected": "Select element(s) to view properties.",
     "over-limit": "Too many elements selected.",
-    "show-viewport": "Show viewport"
+    "show-viewport": "Show viewport",
+    "error": "Error",
+    "generic-error-description": "An error occurred while loading properties."
   },
   "toast": {
     "link-copied": "URL copied to clipboard."

--- a/app/frontend/src/app/ITwinJsApp/widgets/PropertyGridWidget.scss
+++ b/app/frontend/src/app/ITwinJsApp/widgets/PropertyGridWidget.scss
@@ -19,12 +19,21 @@
   }
 }
 
+.presentation-rules-editor-property-grid {
+  padding: var(--iui-size-2xs);
+  padding-right: 0;
+
+  > div {
+    height: 100%;
+  }
+}
+
 .presentation-rules-editor-property-grid-controls {
   display: none;
   position: absolute;
   right: 0;
   margin: 11px 15px;
-  background: var(--buic-background-2);
+  background: var(--iui-color-background-2);
   z-index: 1;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       react-dom:
         specifier: ^17.0.0
         version: 17.0.2(react@17.0.2)
+      react-error-boundary:
+        specifier: ^4.0.3
+        version: 4.0.3(react@17.0.2)
       react-redux:
         specifier: ^7.2.4
         version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
@@ -6990,6 +6993,15 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
+
+  /react-error-boundary@4.0.3(react@17.0.2):
+    resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.20.13
+      react: 17.0.2
+    dev: false
 
   /react-highlight-words@0.17.0(react@17.0.2):
     resolution: {integrity: sha512-uX1Qh5IGjnLuJT0Zok234QDwRC8h4hcVMnB99Cb7aquB1NlPPDiWKm0XpSZOTdSactvnClCk8LOmVlP+75dgHA==}


### PR DESCRIPTION
Presentation content request errors get "eaten" by `presentation-frontend@3.7`, so e2e test doesn't fail - it's now `.skipped` and should be enabled when we upgrade core packages to `4.0`