### PR TITLE
Disable e2e tests relying on demo iModels

### DIFF
--- a/app/e2e-tests/src/demo-imodel.test.ts
+++ b/app/e2e-tests/src/demo-imodel.test.ts
@@ -5,7 +5,8 @@
 import { page } from "./setup";
 import { getWidget, openDemoIModel } from "./utils";
 
-describe("demo iModel #web", () => {
+// TODO: enable this test when demo imodels work in all environments.
+describe.skip("demo iModel #web", () => {
   it("opens", async () => {
     await openDemoIModel(page);
     const treeWidget = getWidget(page, "Tree");

--- a/app/e2e-tests/src/share.test.ts
+++ b/app/e2e-tests/src/share.test.ts
@@ -41,7 +41,8 @@ describe("opening shared link #local #web", () => {
     ? `${getServiceUrl()}/open-imodel?iTwinId=b27dc251-0e53-4a36-9a38-182fc309be07&iModelId=f30566da-8fdf-4cba-b09a-fd39f5397ae6`
     : `${getServiceUrl()}/open-imodel?snapshot=Baytown.bim`;
 
-  it("populates editor with ruleset and loads widget data when link is valid", async () => {
+  // TODO: enable this test when demo imodels work in all environments.
+  it.skip("populates editor with ruleset and loads widget data when link is valid", async () => {
     await page.goto(
       `${baseAddress}#editor/N4IgTgrgNgpgzjALiAXCYAdAdgAhxkASwBMCV8RF5EB9SWBRAgGmzwPvjJwG028cmXAPbhoMACoBPAA4xuBAEoB7ZYgByy4lxCthIgnDkBjQgDNCxgIaJCyrHG599Iwf1cDDJ6XIUgAwhBwiMoAtpraLO4eFIiy8qix1FEuHgRQVgBGMFB+VME0WFoJ0SIAvqU4ALrRFcI1WGUgZUA`,
     );


### PR DESCRIPTION
Disable e2e tests using demo iModels until they are working in all environments.