### PR TITLE
Fix local authorization

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -65,7 +65,7 @@
     "monaco-editor": "^0.40.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "npm-run-all": "^4.1.5",
-    "oidc-client-ts": "^3.0.1",
+    "oidc-client-ts": "^3.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^4.0.13",

--- a/app/frontend/src/app/Authorization.tsx
+++ b/app/frontend/src/app/Authorization.tsx
@@ -52,27 +52,27 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
 
   const demoAuthorizationClient = new DemoAuthClient();
 
+  const signIn = async () => {
+    try {
+      await userManager.signinRedirect({
+        state: window.location.pathname + window.location.search + window.location.hash,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(err);
+    }
+  };
+
+  const signOut = async () => {
+    try {
+      await userManager.signoutRedirect();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(err);
+    }
+  };
+
   return function AuthorizationProvider(props: React.PropsWithChildren<{}>): React.ReactElement {
-    const signIn = async () => {
-      try {
-        await userManager.signinRedirect({
-          state: window.location.pathname + window.location.search + window.location.hash,
-        });
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(err);
-      }
-    };
-
-    const signOut = async () => {
-      try {
-        await userManager.signoutRedirect();
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(err);
-      }
-    };
-
     const [authorizationContextValue, setAuthorizationContextValue] = React.useState<AuthorizationContext>({
       userManager,
       demoAuthorizationClient,

--- a/app/frontend/src/app/Authorization.tsx
+++ b/app/frontend/src/app/Authorization.tsx
@@ -111,26 +111,22 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
       userManager.events.addUserLoaded(handleUserLoaded);
       userManager.events.addUserUnloaded(handleUserUnloaded);
 
-      let disposed = false;
-      if (!disposed) {
-        userManager
-          .getUser()
-          .then((user) => {
-            if (user === null) {
-              handleUserUnloaded();
-              return;
-            }
-            handleUserLoaded(user);
-          })
-          .catch((e) => {
-            // eslint-disable-next-line no-console
-            console.warn(e);
+      userManager
+        .getUser()
+        .then((user) => {
+          if (user === null) {
             handleUserUnloaded();
-          });
-      }
+            return;
+          }
+          handleUserLoaded(user);
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.warn(e);
+          handleUserUnloaded();
+        });
 
       return () => {
-        disposed = true;
         userManager.events.removeUserLoaded(handleUserLoaded);
         userManager.events.removeUserUnloaded(handleUserUnloaded);
       };

--- a/app/frontend/src/app/Authorization.tsx
+++ b/app/frontend/src/app/Authorization.tsx
@@ -111,22 +111,26 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
       userManager.events.addUserLoaded(handleUserLoaded);
       userManager.events.addUserUnloaded(handleUserUnloaded);
 
-      userManager
-        .getUser()
-        .then((user) => {
-          if (user === null) {
+      let disposed = false;
+      if (!disposed) {
+        userManager
+          .getUser()
+          .then((user) => {
+            if (user === null) {
+              handleUserUnloaded();
+              return;
+            }
+            handleUserLoaded(user);
+          })
+          .catch((e) => {
+            // eslint-disable-next-line no-console
+            console.warn(e);
             handleUserUnloaded();
-            return;
-          }
-          handleUserLoaded(user);
-        })
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.warn(e);
-          handleUserUnloaded();
-        });
+          });
+      }
 
       return () => {
+        disposed = true;
         userManager.events.removeUserLoaded(handleUserLoaded);
         userManager.events.removeUserUnloaded(handleUserUnloaded);
       };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,8 +312,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       oidc-client-ts:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.1.0
+        version: 3.1.0
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -6652,8 +6652,8 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: false
 
-  /oidc-client-ts@3.0.1:
-    resolution: {integrity: sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==}
+  /oidc-client-ts@3.1.0:
+    resolution: {integrity: sha512-IDopEXjiwjkmJLYZo6BTlvwOtnlSniWZkKZoXforC/oLZHC9wkIxd25Kwtmo5yKFMMVcsp3JY6bhcNJqdYk8+g==}
     engines: {node: '>=18'}
     dependencies:
       jwt-decode: 4.0.0


### PR DESCRIPTION
There is a problem with authorization when developing locally: SilentSignIn returns an error message `interaction_required` (https://bentleycs.visualstudio.com/beconnect/_wiki/wikis/beconnect.wiki/49503/Silent-Reauthentication#:~:text=interaction_required). This does not seem to be the case on the deployed website.
Currently, SilentSignIn is called every time the page is refreshed, and also, when accessToken is about to expire.
Changed the implementation, now SilentSignIn is called only when accessToken is about to expire. When page is refreshed, SilentSignIn is no longer called, instead, `getUser()` is used to retrieve user data.