### PR TITLE
Update test setup for web tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,26 @@ To summarize, we only do string localization inside `ITwinJsApp/` subdirectory.
 We have two sets of tests:
 
 - Unit tests for `presentation-rules-editor` package, which require 100% test coverage.
-- End-to-end tests for the editor application.
 
-To run these tests, execute `npm test` in `presentation-rules-editor-react/` and `app/e2e-tests/` directories respectively.
+  - To run these tests navigate to `presentation-rules-editor-react/` and execute:
+
+  ```bash
+   npm test
+  ```
+
+- End-to-end tests for the editor application. These tests are split into `web` and `local` tests.
+
+  - To run `web` tests navigate to `app/e2e-tests/` and execute:
+
+  ```bash
+   npm run test:web
+  ```
+
+  - To run `local` tests navigate to `app/e2e-tests/` and execute:
+
+  ```bash
+   npm run test:local
+  ```
 
 ## Debugging
 

--- a/app/e2e-tests/src/imodel.setup.ts
+++ b/app/e2e-tests/src/imodel.setup.ts
@@ -7,8 +7,10 @@ import { exec } from "child_process";
 import * as fs from "fs";
 import { test as setup } from "@playwright/test";
 
-setup("Setup Baytown #web #local", async () => {
-  await setupIModel();
+setup("Setup Baytown", async () => {
+  if (!process.env.WEB_TEST) {
+    await setupIModel();
+  }
 });
 
 async function setupIModel(): Promise<void> {


### PR DESCRIPTION
Current e2e test setup downloads Batown.bim to the backend folder. This is not needed for web tests as they don't use `backend` package.
Adjusted the setup to not download Baytown.bim for `web` tests.
Updated `CONTRIBUTING.md` since it wasn't updated previously after changing how e2e tests are supposed to be run.