### PR TITLE
Adjust import of StationPropertyValueRenderer

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
+    "preview": "vite preview",
     "lint": "eslint ./src/**/*.{ts,tsx}",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch"

--- a/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/ITwinJsApp.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import "../experimental/StationPropertyValueRenderer.js";
 import * as React from "react";
 import { rpcInterfaces } from "@app/common";
 import { AppNotificationManager, UiFramework } from "@itwin/appui-react";
@@ -14,14 +15,10 @@ import { FrontendIModelsAccess } from "@itwin/imodels-access-frontend";
 import { IModelsClient } from "@itwin/imodels-client-management";
 import { Presentation } from "@itwin/presentation-frontend";
 import { LoadingIndicator } from "../common/LoadingIndicator.js";
-import { applyUrlPrefix, EXPERIMENTAL_STATION_VALUE_RENDERER } from "../utils/Environment.js";
+import { applyUrlPrefix } from "../utils/Environment.js";
 import { BackendApi } from "./api/BackendApi.js";
 import { demoIModels, IModelIdentifier } from "./IModelIdentifier.js";
 import { InitializedApp } from "./InitializedApp.js";
-
-if (EXPERIMENTAL_STATION_VALUE_RENDERER) {
-  await import("../experimental/StationPropertyValueRenderer.js");
-}
 
 export interface ITwinJsAppProps {
   backendApiPromise: Promise<BackendApi>;

--- a/app/frontend/src/app/utils/Environment.ts
+++ b/app/frontend/src/app/utils/Environment.ts
@@ -17,5 +17,3 @@ export function applyUrlPrefix(url: string): string {
 export const clientId = import.meta.env.OAUTH_CLIENT_ID;
 export const urlPrefix = import.meta.env.IMJS_URL_PREFIX;
 export const appInsightsConnectionString = import.meta.env.APPLICATION_INSIGHTS_CONNECTION_STRING;
-
-export const EXPERIMENTAL_STATION_VALUE_RENDERER = true;

--- a/app/frontend/vite.config.mts
+++ b/app/frontend/vite.config.mts
@@ -31,10 +31,9 @@ export default defineConfig(({ mode }) => {
       port: 3000,
       strictPort: true,
     },
-    esbuild: {
-      supported: {
-        "top-level-await": true, // browsers can handle top-level-await features
-      },
+    preview: {
+      port: 3000,
+      strictPort: true,
     },
     css: {
       preprocessorOptions: {


### PR DESCRIPTION
In https://github.com/iTwin/presentation-rules-editor/pull/173 `await` was added before `import("../experimental/StationPropertyValueRenderer.js")` in `ITwinJsApp.tsx`. This seems to work when running with start option, but does not work with production build.
Decided to remove the `EXPERIMENTAL_STATION_VALUE_RENDERER` value, as it always has a `true` value and we never change it. This allows us to remove the `await` and import it normally.