### PR TITLE
Fix monaco editor

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -73,7 +73,6 @@
     "tslib": "^2.8.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.2",
-    "vite-plugin-monaco-editor": "1.1.0",
     "vite-plugin-static-copy": "^2.2.0"
   }
 }

--- a/app/frontend/src/app/App.tsx
+++ b/app/frontend/src/app/App.tsx
@@ -57,7 +57,7 @@ const AuthorizationProvider = clientId
       redirect_uri: "/auth/callback",
       silent_redirect_uri: "/auth/silent",
       post_logout_redirect_uri: "/",
-      scope: "itwin-platform itwinjs openid profile",
+      scope: "itwin-platform openid profile",
     })
   : (props: React.PropsWithChildren<object>) => <>{props.children}</>;
 

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -4,9 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import "./index.scss";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app/App.js";
+
+// setup environment for monaco editor
+// loading only json and default workers as other languages are not used.
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === "json") {
+      return new jsonWorker();
+    }
+    return new editorWorker();
+  },
+};
 
 const div = document.createElement("div");
 div.className = "app";

--- a/app/frontend/vite.config.mts
+++ b/app/frontend/vite.config.mts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { defineConfig, loadEnv } from "vite";
-import monacoEditorPlugin from "vite-plugin-monaco-editor";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import react from "@vitejs/plugin-react";
 
@@ -23,9 +22,6 @@ export default defineConfig(({ mode }) => {
             dest: ".",
           },
         ],
-      }),
-      monacoEditorPlugin.default({
-        languageWorkers: ["json"],
       }),
     ],
     server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,9 +311,6 @@ importers:
       vite:
         specifier: ^6.0.2
         version: 6.0.3(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.2)
-      vite-plugin-monaco-editor:
-        specifier: 1.1.0
-        version: 1.1.0(monaco-editor@0.52.2)
       vite-plugin-static-copy:
         specifier: ^2.2.0
         version: 2.2.0(vite@6.0.3(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.2))
@@ -4160,11 +4157,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vite-plugin-monaco-editor@1.1.0:
-    resolution: {integrity: sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==}
-    peerDependencies:
-      monaco-editor: '>=0.33.0'
 
   vite-plugin-static-copy@2.2.0:
     resolution: {integrity: sha512-ytMrKdR9iWEYHbUxs6x53m+MRl4SJsOSoMu1U1+Pfg0DjPeMlsRVx3RR5jvoonineDquIue83Oq69JvNsFSU5w==}
@@ -8474,10 +8466,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   vary@1.1.2: {}
-
-  vite-plugin-monaco-editor@1.1.0(monaco-editor@0.52.2):
-    dependencies:
-      monaco-editor: 0.52.2
 
   vite-plugin-static-copy@2.2.0(vite@6.0.3(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.2)):
     dependencies:


### PR DESCRIPTION
Updated monaco editor setup based on https://github.com/microsoft/monaco-editor/blob/main/docs/integrate-esm.md#using-vite instead of third party plugin.

Removed unnecessary `itwinjs` scope from auth provider.