### PR TITLE
Fix some UI problems

### DIFF
--- a/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/IModelBrowser.tsx
@@ -293,7 +293,7 @@ export function IModelTile(props: IModelTileProps): React.ReactElement {
     <Tile
       name={props.name}
       description={props.description ?? <Text isSkeleton />}
-      thumbnail={thumbnail ? <img style={{ objectFit: "cover" }} src={thumbnail} alt="" /> : <div ref={divRef} id="imodel-thumbnail-placeholder" />}
+      thumbnail={thumbnail ? thumbnail : <div ref={divRef} id="imodel-thumbnail-placeholder" />}
       isActionable
       onClick={async () => navigation.openRulesetEditor({ iTwinId: props.iTwinId, iModelId: props.iModelId })}
     />
@@ -307,14 +307,6 @@ export interface IModelSnapshotTileProps {
 
 export function IModelSnapshotTile(props: IModelSnapshotTileProps): React.ReactElement {
   const navigation = React.useContext(appNavigationContext);
-  const handleTileClick = async (event: React.MouseEvent) => {
-    // This function is called whenever any element within the tile is clicked
-    if ((event.target as Element).matches("button[aria-label='More options'], button[aria-label='More options'] *")) {
-      return;
-    }
-
-    await navigation.openRulesetEditor(props.name);
-  };
 
   return (
     <Tile
@@ -322,7 +314,7 @@ export function IModelSnapshotTile(props: IModelSnapshotTileProps): React.ReactE
       description="Snapshot iModel"
       thumbnail={<SvgImodel />}
       isActionable
-      onClick={async (event) => handleTileClick(event)}
+      onClick={async () => navigation.openRulesetEditor(props.name)}
       moreOptions={[
         <MenuItem key="open-folder" onClick={props.openSnapshotsFolder}>
           Open containing folder

--- a/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
+++ b/app/frontend/src/app/IModelBrowser/ITwinIModelBrowser.tsx
@@ -88,16 +88,15 @@ function ITwinBrowserGridView(props: ITwinBrowserGridViewProps): React.ReactElem
   return (
     <FluidGrid>
       {props.iTwins.map((iTwin) => (
-        <div key={iTwin.id}>
-          <Tile
-            name={iTwin.displayName}
-            variant="folder"
-            isActionable
-            thumbnail={iTwin.image ?? <SvgProject />}
-            description={iTwin.number}
-            onClick={async () => navigate(iTwin.id)}
-          />
-        </div>
+        <Tile
+          key={iTwin.id}
+          name={iTwin.displayName}
+          variant="folder"
+          isActionable
+          thumbnail={iTwin.image ?? <SvgProject />}
+          description={iTwin.number}
+          onClick={async () => navigate(iTwin.id)}
+        />
       ))}
     </FluidGrid>
   );

--- a/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
+++ b/app/frontend/src/app/ITwinJsApp/InitializedApp.tsx
@@ -99,8 +99,8 @@ const defaultRuleset: Ruleset = {
           classes: {
             schemaName: "BisCore",
             classNames: ["Element"],
+            arePolymorphic: true,
           },
-          arePolymorphic: true,
           groupByClass: true,
         },
       ],


### PR DESCRIPTION
Fixed iModel tile thumbnails not taking all the space available.
Removed workaround for accessing `More` menu in snapshot tile.
Updated default ruleset to avoid deprecation warning in editor.

There is still one issue with iTwin tiles when iTwins have long names. Filled an issue: https://github.com/iTwin/iTwinUI/issues/2376