### PR TITLE
Fix build pipeline

### DIFF
--- a/.pipelines/build-app.yml
+++ b/.pipelines/build-app.yml
@@ -69,6 +69,10 @@ jobs:
       - script: pnpm install --filter @app/frontend...
 
       - script: npm run build
+        env:
+          OAUTH_CLIENT_ID: "#{App.ClientId}"
+          IMJS_URL_PREFIX: "#{App.UrlPrefix}"
+          APPLICATION_INSIGHTS_CONNECTION_STRING: "#{App.AppInsightsConnectionString}"
         displayName: Bundle
 
       - task: octopusdeploy.octopus-deploy-build-release-tasks.octopus-pack-nuget.OctopusPackNuGet@6


### PR DESCRIPTION
Set env variables when bundling the app, otherwise we don't create meta tags for them, and release pipeline can't inject custom values for them.