### PR TITLE
Remove unnecessary `console.error` call

### DIFF
--- a/app/frontend/src/app/Authorization.tsx
+++ b/app/frontend/src/app/Authorization.tsx
@@ -211,8 +211,6 @@ export function SignInCallback(): React.ReactElement {
     const errorCode = params.get("error");
     const errorDescription = params.get("error_description");
     if (isOAuthErrorCode(errorCode)) {
-      // eslint-disable-next-line no-console
-      console.error(`Authorization error (${errorCode}): ${errorDescription ?? ""}`);
       setAuthError({ code: errorCode, description: errorDescription ?? undefined });
       return;
     }


### PR DESCRIPTION
Should close https://github.com/iTwin/presentation-rules-editor/security/code-scanning/4