### PR TITLE
Bump `vite` to `6.3.0`

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -72,7 +72,7 @@
     "sass": "^1.82.0",
     "tslib": "^2.8.1",
     "typescript": "^5.7.2",
-    "vite": "^6.2.2",
+    "vite": "^6.3.0",
     "vite-plugin-static-copy": "^2.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         version: 7.1.34
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))
+        version: 4.3.4(vite@6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))
       cpx2:
         specifier: ^8.0.0
         version: 8.0.0
@@ -310,11 +310,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       vite:
-        specifier: ^6.2.2
-        version: 6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
+        specifier: ^6.3.0
+        version: 6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
       vite-plugin-static-copy:
         specifier: ^2.2.0
-        version: 2.2.0(vite@6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))
+        version: 2.2.0(vite@6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))
 
   presentation-rules-editor-react:
     devDependencies:
@@ -2475,6 +2475,14 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.4.3:
+    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3355,6 +3363,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
     engines: {node: '>=0.10'}
@@ -3852,6 +3864,10 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
@@ -4031,8 +4047,8 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
 
-  vite@6.2.2:
-    resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+  vite@6.3.0:
+    resolution: {integrity: sha512-9aC0n4pr6hIbvi1YOpFjwQ+QOTGssvbJKoeYkuHHGWwlXfdxQlI8L2qNMo9awEEcCPSiS+5mJZk5jH1PAqoDeQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -5675,14 +5691,14 @@ snapshots:
       '@typescript-eslint/types': 8.11.0
       eslint-visitor-keys: 3.4.3
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))':
+  '@vitejs/plugin-react@4.3.4(vite@6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
+      vite: 6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6622,6 +6638,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.4.3(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -7500,6 +7520,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
@@ -8073,6 +8095,11 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tippy.js@6.3.7:
     dependencies:
       '@popperjs/core': 2.11.8
@@ -8252,19 +8279,22 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-static-copy@2.2.0(vite@6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)):
+  vite-plugin-static-copy@2.2.0(vite@6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)):
     dependencies:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.1.1
-      vite: 6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
+      vite: 6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3)
 
-  vite@6.2.2(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3):
+  vite@6.3.0(@types/node@20.17.10)(sass@1.83.0)(tsx@4.19.3):
     dependencies:
       esbuild: 0.25.1
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.36.0
+      tinyglobby: 0.2.12
     optionalDependencies:
       '@types/node': 20.17.10
       fsevents: 2.3.3


### PR DESCRIPTION
Closes https://github.com/iTwin/presentation-rules-editor/security/dependabot/44
Closes https://github.com/iTwin/presentation-rules-editor/security/dependabot/43
Closes https://github.com/iTwin/presentation-rules-editor/security/dependabot/42
Closes https://github.com/iTwin/presentation-rules-editor/security/dependabot/41